### PR TITLE
use link-to for .site-name link

### DIFF
--- a/app/templates/components/site-header.hbs
+++ b/app/templates/components/site-header.hbs
@@ -3,7 +3,7 @@
   <div class="grid-x grid-padding-x">
     <div class="branding cell shrink large-auto">
       <a class="dcp-link" href="http://www1.nyc.gov/site/planning/index.page"><img class="dcp-logo" src="https://raw.githubusercontent.com/NYCPlanning/logo/master/dcp_logo_772.png" alt="NYC Planning"></a>
-      <a href="#" class="site-name">Fact Finder <small class="site-subtitle show-for-medium">Population Information for N<span class="show-for-large">ew </span>Y<span class="show-for-large">ork </span>C<span class="show-for-large">ity</span></small></a>
+      {{#link-to 'index' classNames='site-name'}}Fact Finder <small class="site-subtitle show-for-medium">Population Information for N<span class="show-for-large">ew </span>Y<span class="show-for-large">ork </span>C<span class="show-for-large">ity</span></small>{{/link-to}}
     </div>
     <div class="cell auto hide-for-large text-right">
       <button {{action (mut closed) (not closed)}} class="responsive-nav-toggler hide-for-print" data-toggle="responsive-menu">Menu</button>


### PR DESCRIPTION
This PR uses the `{{link-to}}` component for the `.site-name`. 
(It was just using `a href="#"`.)