### PR TITLE
Cw numeral format

### DIFF
--- a/app/helpers/numeral-format.js
+++ b/app/helpers/numeral-format.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import numeral from 'numeral';
+
+export function numeralFormat(params) {
+  const [number, template] = params;
+  return numeral(number).format(template || '0,0');
+}
+
+export default Ember.Helper.helper(numeralFormat);

--- a/app/templates/report/demographic.hbs
+++ b/app/templates/report/demographic.hbs
@@ -17,128 +17,128 @@
   <tbody>
     <tr class="row-highlight">
       <td>Total population</td>
-      <td class="cell-narrow">{{model.sex_and_age.pop_1.sum}}</td>
+      <td class="cell-narrow">{{numeral-format model.sex_and_age.pop_1.sum}}</td>
     </tr>
     <tr>
       <td>Male</td>
-      <td>{{model.sex_and_age.male.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.male.sum}}</td>
     </tr>
     <tr>
       <td>Female</td>
-      <td>{{model.sex_and_age.fem.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.fem.sum}}</td>
     </tr>
     <tr class="row-divider"><td colspan="2"></td></tr>
     <tr>
       <td>Under 5 years</td>
-      <td>{{model.sex_and_age.popu5.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.popu5.sum}}</td>
     </tr>
     <tr>
       <td>5 to 9 years</td>
-      <td>{{model.sex_and_age.pop5t9.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop5t9.sum}}</td>
     </tr>
     <tr>
       <td>10 to 14 years</td>
-      <td>{{model.sex_and_age.pop10t14.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop10t14.sum}}</td>
     </tr>
     <tr>
       <td>15 to 19 years</td>
-      <td>{{model.sex_and_age.pop15t19.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop15t19.sum}}</td>
     </tr>
     <tr>
       <td>20 to 24 years</td>
-      <td>{{model.sex_and_age.pop20t24.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop20t24.sum}}</td>
     </tr>
     <tr>
       <td>25 to 29 years</td>
-      <td>{{model.sex_and_age.pop25t29.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop25t29.sum}}</td>
     </tr>
     <tr>
       <td>30 to 34 years</td>
-      <td>{{model.sex_and_age.pop30t34.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop30t34.sum}}</td>
     </tr>
     <tr>
       <td>35 to 39 years</td>
-      <td>{{model.sex_and_age.pop35t39.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop35t39.sum}}</td>
     </tr>
     <tr>
       <td>40 to 44 years</td>
-      <td>{{model.sex_and_age.pop40t44.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop40t44.sum}}</td>
     </tr>
     <tr>
       <td>45 to 49 years</td>
-      <td>{{model.sex_and_age.pop45t49.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop45t49.sum}}</td>
     </tr>
     <tr>
       <td>50 to 54 years</td>
-      <td>{{model.sex_and_age.pop50t54.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop50t54.sum}}</td>
     </tr>
     <tr>
       <td>55 to 59 years</td>
-      <td>{{model.sex_and_age.pop55t59.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop55t59.sum}}</td>
     </tr>
     <tr>
       <td>60 to 64 years</td>
-      <td>{{model.sex_and_age.pop60t64.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop60t64.sum}}</td>
     </tr>
     <tr>
       <td>65 to 69 years</td>
-      <td>{{model.sex_and_age.pop65t69.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop65t69.sum}}</td>
     </tr>
     <tr>
       <td>70 to 74 years</td>
-      <td>{{model.sex_and_age.pop70t74.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop70t74.sum}}</td>
     </tr>
     <tr>
       <td>75 to 79 years</td>
-      <td>{{model.sex_and_age.pop75t79.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop75t79.sum}}</td>
     </tr>
     <tr>
       <td>80 to 84 years</td>
-      <td>{{model.sex_and_age.pop80t84.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop80t84.sum}}</td>
     </tr>
     <tr>
       <td>85 years and over</td>
-      <td>{{model.sex_and_age.pop85pl.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop85pl.sum}}</td>
     </tr>
     <tr class="row-divider"><td colspan="2"></td></tr>
     <tr>
       <td>Under 18 years</td>
-      <td>{{model.sex_and_age.popu181.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.popu181.sum}}</td>
     </tr>
     <tr>
       <td>65 years and over</td>
-      <td>{{model.sex_and_age.pop65pl1.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop65pl1.sum}}</td>
     </tr>
     <tr class="row-divider"><td colspan="2"></td></tr>
     <tr>
       <td>Median age (years)</td>
-      <td>{{model.sex_and_age.mdage.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.mdage.sum}}</td>
     </tr>
     <tr class="row-divider"><td colspan="2"></td></tr>
     <tr class="row-highlight">
       <td>Under 18 years</td>
-      <td>{{model.sex_and_age.popu18_2.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.popu18_2.sum}}</td>
     </tr>
     <tr>
       <td>Male</td>
-      <td>{{model.sex_and_age.popu18m.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.popu18m.sum}}</td>
     </tr>
     <tr>
       <td>Female</td>
-      <td>{{model.sex_and_age.popu18f.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.popu18f.sum}}</td>
     </tr>
     <tr class="row-divider"><td colspan="2"></td></tr>
     <tr class="row-highlight">
       <td>65 years and over</td>
-      <td>{{model.sex_and_age.pop65pl2.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop65pl2.sum}}</td>
     </tr>
     <tr>
       <td>Male</td>
-      <td>{{model.sex_and_age.pop65plm.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop65plm.sum}}</td>
     </tr>
     <tr>
       <td>Female</td>
-      <td>{{model.sex_and_age.pop65plf.sum}}</td>
+      <td>{{numeral-format model.sex_and_age.pop65plf.sum}}</td>
     </tr>
   </tbody>
 </table>
@@ -152,43 +152,43 @@
   <tbody>
     <tr class="row-highlight">
       <td>Total population</td>
-      <td class="cell-narrow">{{model.mutually_exclusive_race_hispanic_origin.pop_2.sum}}</td>
+      <td class="cell-narrow">{{numeral-format model.mutually_exclusive_race_hispanic_origin.pop_2.sum}}</td>
     </tr>
     <tr>
       <td>Hispanic/Latino (of any race)</td>
-      <td>{{model.mutually_exclusive_race_hispanic_origin.hsp1.sum}}</td>
+      <td>{{numeral-format model.mutually_exclusive_race_hispanic_origin.hsp1.sum}}</td>
     </tr>
     <tr>
       <td>Not Hispanic/Latino</td>
-      <td>{{model.mutually_exclusive_race_hispanic_origin.nhsp.sum}}</td>
+      <td>{{numeral-format model.mutually_exclusive_race_hispanic_origin.nhsp.sum}}</td>
     </tr>
     <tr>
       <td class="indented">White alone</td>
-      <td>{{model.mutually_exclusive_race_hispanic_origin.wtnh.sum}}</td>
+      <td>{{numeral-format model.mutually_exclusive_race_hispanic_origin.wtnh.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Black or African American alone</td>
-      <td>{{model.mutually_exclusive_race_hispanic_origin.blnh.sum}}</td>
+      <td>{{numeral-format model.mutually_exclusive_race_hispanic_origin.blnh.sum}}</td>
     </tr>
     <tr>
       <td class="indented">American Indian and Alaska Native alone</td>
-      <td>{{model.mutually_exclusive_race_hispanic_origin.aiannh.sum}}</td>
+      <td>{{numeral-format model.mutually_exclusive_race_hispanic_origin.aiannh.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Asian alone</td>
-      <td>{{model.mutually_exclusive_race_hispanic_origin.asnnh.sum}}</td>
+      <td>{{numeral-format model.mutually_exclusive_race_hispanic_origin.asnnh.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Native Hawaiian and Other Pacific Islander alone</td>
-      <td>{{model.mutually_exclusive_race_hispanic_origin.nhpinh.sum}}</td>
+      <td>{{numeral-format model.mutually_exclusive_race_hispanic_origin.nhpinh.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Some other race alone</td>
-      <td>{{model.mutually_exclusive_race_hispanic_origin.othnh.sum}}</td>
+      <td>{{numeral-format model.mutually_exclusive_race_hispanic_origin.othnh.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Two or more races</td>
-      <td>{{model.mutually_exclusive_race_hispanic_origin.rc2plnh.sum}}</td>
+      <td>{{numeral-format model.mutually_exclusive_race_hispanic_origin.rc2plnh.sum}}</td>
     </tr>
   </tbody>
 </table>
@@ -202,119 +202,119 @@
   <tbody>
     <tr class="row-highlight">
       <td>Hispanic/Latino</td>
-      <td class="cell-narrow">{{model.hispanic_subgroup.hsp2.sum}}</td>
+      <td class="cell-narrow">{{numeral-format model.hispanic_subgroup.hsp2.sum}}</td>
     </tr>
     <tr>
       <td>Mexican</td>
-      <td>{{model.hispanic_subgroup.hspme.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspme.sum}}</td>
     </tr>
     <tr>
       <td>Puerto Rican</td>
-      <td>{{model.hispanic_subgroup.hsppr.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hsppr.sum}}</td>
     </tr>
     <tr>
       <td>Cuban</td>
-      <td>{{model.hispanic_subgroup.hspcub.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspcub.sum}}</td>
     </tr>
     <tr>
       <td>Dominican (Dominican Republic)</td>
-      <td>{{model.hispanic_subgroup.hspdom.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspdom.sum}}</td>
     </tr>
     <tr>
       <td>Central American</td>
-      <td>{{model.hispanic_subgroup.hspcam.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspcam.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Costa Rican</td>
-      <td>{{model.hispanic_subgroup.hspcr.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspcr.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Guatemalan</td>
-      <td>{{model.hispanic_subgroup.hspguatm.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspguatm.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Honduran</td>
-      <td>{{model.hispanic_subgroup.hsphnd.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hsphnd.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Nicaraguan</td>
-      <td>{{model.hispanic_subgroup.hspnic.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspnic.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Panamanian</td>
-      <td>{{model.hispanic_subgroup.hsppan.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hsppan.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Salvadoran</td>
-      <td>{{model.hispanic_subgroup.hspsalv.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspsalv.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Other Central American</td>
-      <td>{{model.hispanic_subgroup.hspocam.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspocam.sum}}</td>
     </tr>
     <tr>
       <td>South American</td>
-      <td>{{model.hispanic_subgroup.hspsam.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspsam.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Argentinean</td>
-      <td>{{model.hispanic_subgroup.hsparg.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hsparg.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Bolivian</td>
-      <td>{{model.hispanic_subgroup.hspbol.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspbol.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Chilean</td>
-      <td>{{model.hispanic_subgroup.hspchl.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspchl.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Colombian</td>
-      <td>{{model.hispanic_subgroup.hspcol.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspcol.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Ecuadorian</td>
-      <td>{{model.hispanic_subgroup.hspec.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspec.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Paraguayan</td>
-      <td>{{model.hispanic_subgroup.hspprg.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspprg.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Peruvian</td>
-      <td>{{model.hispanic_subgroup.hspperu.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspperu.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Uruguayan</td>
-      <td>{{model.hispanic_subgroup.hspurg.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspurg.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Venezuelan</td>
-      <td>{{model.hispanic_subgroup.hspvnz.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspvnz.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Other South American</td>
-      <td>{{model.hispanic_subgroup.hsposam.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hsposam.sum}}</td>
     </tr>
     <tr>
       <td>Other Hispanic/Latino</td>
-      <td>{{model.hispanic_subgroup.hspoth.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspoth.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Spaniard</td>
-      <td>{{model.hispanic_subgroup.hspspnrd.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspspnrd.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Spanish</td>
-      <td>{{model.hispanic_subgroup.hspspnsh.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspspnsh.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Spanish American</td>
-      <td>{{model.hispanic_subgroup.hspspam.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspspam.sum}}</td>
     </tr>
     <tr>
       <td class="indented">All other Hispanic/Latino</td>
-      <td>{{model.hispanic_subgroup.hspalloth.sum}}</td>
+      <td>{{numeral-format model.hispanic_subgroup.hspalloth.sum}}</td>
     </tr>
   </tbody>
 </table>
@@ -328,111 +328,111 @@
   <tbody>
     <tr class="row-highlight">
       <td>Asian Alone</td>
-      <td class="cell-narrow">{{model.asian_subgroup.asn1rc.sum}}</td>
+      <td class="cell-narrow">{{numeral-format model.asian_subgroup.asn1rc.sum}}</td>
     </tr>
     <tr>
       <td>East Asian</td>
-      <td>{{model.asian_subgroup.asneast.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asneast.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Chinese, except Taiwanese</td>
-      <td>{{model.asian_subgroup.asnchinot.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnchinot.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Japanese</td>
-      <td>{{model.asian_subgroup.asnjpn.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnjpn.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Korean</td>
-      <td>{{model.asian_subgroup.asnkor.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnkor.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Mongolian</td>
-      <td>{{model.asian_subgroup.asnmgol.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnmgol.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Okinawan</td>
-      <td>{{model.asian_subgroup.asnokinw.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnokinw.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Taiwanese</td>
-      <td>{{model.asian_subgroup.asntwn.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asntwn.sum}}</td>
     </tr>
     <tr>
       <td>South Asian</td>
-      <td>{{model.asian_subgroup.asnsouth.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnsouth.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Asian Indian</td>
-      <td>{{model.asian_subgroup.asnind.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnind.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Bangladeshi</td>
-      <td>{{model.asian_subgroup.asnbng.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnbng.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Bhutanese</td>
-      <td>{{model.asian_subgroup.asnbhutn.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnbhutn.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Nepalese</td>
-      <td>{{model.asian_subgroup.asnnepal.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnnepal.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Pakistani</td>
-      <td>{{model.asian_subgroup.asnpak.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnpak.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Sri Lankan</td>
-      <td>{{model.asian_subgroup.asnsril.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnsril.sum}}</td>
     </tr>
     <tr>
       <td>Southeast Asian</td>
-      <td>{{model.asian_subgroup.asnseast.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnseast.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Burmese</td>
-      <td>{{model.asian_subgroup.asnburm.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnburm.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Cambodian</td>
-      <td>{{model.asian_subgroup.asncmb.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asncmb.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Filipino</td>
-      <td>{{model.asian_subgroup.asnflp.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnflp.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Hmong</td>
-      <td>{{model.asian_subgroup.asnhmng.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnhmng.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Indonesian</td>
-      <td>{{model.asian_subgroup.asnindnsn.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnindnsn.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Laotian</td>
-      <td>{{model.asian_subgroup.asnlao.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnlao.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Malaysian</td>
-      <td>{{model.asian_subgroup.asnmalsn.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnmalsn.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Thai</td>
-      <td>{{model.asian_subgroup.asnthai.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnthai.sum}}</td>
     </tr>
     <tr>
       <td class="indented">Vietnamese</td>
-      <td>{{model.asian_subgroup.asnvtn.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnvtn.sum}}</td>
     </tr>
     <tr>
       <td>Other Asian</td>
-      <td>{{model.asian_subgroup.asnoasn.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asnoasn.sum}}</td>
     </tr>
     <tr>
       <td>Two or more Asian</td>
-      <td>{{model.asian_subgroup.asn2pl.sum}}</td>
+      <td>{{numeral-format model.asian_subgroup.asn2pl.sum}}</td>
     </tr>
   </tbody>
 </table>

--- a/tests/integration/helpers/numeral-format-test.js
+++ b/tests/integration/helpers/numeral-format-test.js
@@ -1,0 +1,17 @@
+
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('numeral-format', 'helper:numeral-format', {
+  integration: true
+});
+
+// Replace this with your real tests.
+test('it renders', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{numeral-format inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '1234');
+});
+

--- a/tests/integration/helpers/numeral-format-test.js
+++ b/tests/integration/helpers/numeral-format-test.js
@@ -12,6 +12,5 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{numeral-format inputValue}}`);
 
-  assert.equal(this.$().text().trim(), '1234');
+  assert.equal(this.$().text().trim(), '1,234');
 });
-


### PR DESCRIPTION
Adds `numeral-format` helper, which now has a default numeral template of `0,0`, so it can be called without a second parameter, like {{numeral-format somevalue}}

Implements `numeral-format` on all of the values on the demographics page