### PR TITLE
make report map static, remove hash, fitbounds on resize

### DIFF
--- a/app/controllers/report.js
+++ b/app/controllers/report.js
@@ -38,12 +38,20 @@ export default Ember.Controller.extend({
 
   selectedFillLayer,
 
+  fitBounds(map) {
+    const FC = this.get('selection').current;
+    map.fitBounds(bbox(FC), {
+      padding: 40,
+    });
+  },
+
   actions: {
     handleMapLoad(map) {
-      const FC = this.get('selection').current;
-      map.fitBounds(bbox(FC), {
-        padding: 40,
-      });
+      this.fitBounds(map);
+    },
+
+    handleResize(e) {
+      this.fitBounds(e.target);
     },
   },
 

--- a/app/templates/report.hbs
+++ b/app/templates/report.hbs
@@ -28,7 +28,8 @@
         initOptions=(hash style='mapbox://styles/mapbox/light-v9'
                           zoom=zoom
                           center=center
-                          hash=true)
+                          hash=false
+                          interactive=false)
         mapLoaded=(action 'handleMapLoad')
 
         as |map|}}
@@ -45,6 +46,9 @@
               before='waterway-label'}}
           {{/map.source}}
         {{/if}}
+
+        {{map.on 'resize' (action 'handleResize')}}
+
 
       {{/jane-maps}}
     </div>


### PR DESCRIPTION
This PR improves the map on the report view:

- Removes the URL hash
- Makes the map static (non-interactive)
- Fits the map to the bounds of the selected area when the window is resized

Closes #37 