### PR TITLE
Fix bug where very long SQL queries make the URL too long

### DIFF
--- a/app/routes/report.js
+++ b/app/routes/report.js
@@ -92,9 +92,9 @@ export default Ember.Route.extend({
                             FROM support_fact_finder
                             WHERE geoid = '${comparator}'`;
 
-    return carto.SQL(longitudinalSQL)
+    return carto.SQL(longitudinalSQL, 'json', 'post')
       .then(nestedData =>
-        carto.SQL(geographicComparisonSQL)
+        carto.SQL(geographicComparisonSQL, 'json', 'post')
           .then(final => merge(final, nestedData)),
       )
       .then(data => nestReport(data));

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -10,7 +10,8 @@ const BLOCKS_SQL =
       ct2010,
       borocode || ct2010 AS boroct2010,
       bctcb2010,
-      bctcb2010 AS geoid
+      bctcb2010 AS geoid,
+      (ct2010::float / 100)::text || ' - ' || cb2010 as geolabel
     FROM nyc_census_blocks_2010`;
 
 const TRACTS_SQL =

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@turf/bbox": "^5.0.0",
     "babel-eslint": "^8.0.1",
-    "ember-jane-maps": "0.0.3",
+    "ember-jane-maps": "0.0.4",
     "numeral": "^2.0.6"
   }
 }


### PR DESCRIPTION
This PR implements closes #98, where carto SQL api calls were too long when many census blocks are selected.  Now the calls will use POST, which can have a larger payload.