### PR TITLE
AC Table, Report Map tweaks

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -397,6 +397,11 @@ button {
 //
 // Tables
 // --------------------------------------------------
+table,
+.table-scroll {
+  clear: both;
+}
+
 td:not(:first-child) {
   text-align: right;
 }

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -85,6 +85,10 @@ body {
   height: 50vh;
   width: 100%;
   border: 1px solid $medium-gray;
+
+  @include breakpoint(large) {
+    height: calc(100vh - 22rem);
+  }
 }
 
 .map-utility-box {


### PR DESCRIPTION
This PR: 
- Prevent floated elements appearing beside tables
- Auto-sizes the map (was just using mobile height for all screen sizes) 