### PR TITLE
Cw reset ntapuma selections

### DIFF
--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -30,6 +30,7 @@ const NTA_SQL =
     the_geom_webmercator,
     ntaname,
     ntacode,
+    ntacode as geolabel,
     ntacode AS geoid
   FROM support_admin_ntaboundaries`;
 

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -33,15 +33,7 @@ const NTA_SQL =
     ntacode as geolabel,
     ntacode AS geoid
   FROM support_admin_ntaboundaries`;
-
-  const PUMA_SQL = `
-    SELECT
-        the_geom_webmercator,
-        puma AS geolabel,
-        puma AS geoid
-      FROM nyc_puma
-    `;
-
+  
 const DEFAULT_SELECTION = config.DEFAULT_SELECTION;
 const EMPTY_GEOJSON = { type: 'FeatureCollection', features: [] };
 

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -33,7 +33,7 @@ const NTA_SQL =
     ntacode as geolabel,
     ntacode AS geoid
   FROM support_admin_ntaboundaries`;
-  
+
 const DEFAULT_SELECTION = config.DEFAULT_SELECTION;
 const EMPTY_GEOJSON = { type: 'FeatureCollection', features: [] };
 

--- a/app/sources/admin-boundaries.js
+++ b/app/sources/admin-boundaries.js
@@ -4,7 +4,7 @@ export default {
   'source-layers': [
     {
       id: 'neighborhood-tabulation-areas',
-      sql: 'SELECT the_geom_webmercator, ntaname, ntacode, ntacode AS geoid FROM support_admin_ntaboundaries WHERE ntaname NOT ILIKE \'park-cemetery-etc%\'',
+      sql: 'SELECT the_geom_webmercator, ntaname, ntacode, ntacode AS geolabel, ntacode AS geoid FROM support_admin_ntaboundaries WHERE ntaname NOT ILIKE \'park-cemetery-etc%\'',
     },
 
     {

--- a/app/sources/admin-boundaries.js
+++ b/app/sources/admin-boundaries.js
@@ -19,7 +19,7 @@ export default {
 
     {
       id: 'nyc-pumas',
-      sql: 'SELECT the_geom_webmercator, puma, puma AS geoid FROM nyc_puma',
+      sql: 'SELECT the_geom_webmercator, puma AS geolabel, puma AS geoid FROM nyc_puma',
     },
 
     {

--- a/app/sources/census-geoms.js
+++ b/app/sources/census-geoms.js
@@ -11,7 +11,7 @@ export default {
           ctlabel as geolabel,
           boroct2010,
           ntacode,
-          boroct2010 AS geoid 
+          boroct2010 AS geoid
         FROM nyc_census_tracts_2010
       `,
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@turf/bbox": "^5.0.0",
     "babel-eslint": "^8.0.1",
-    "ember-jane-maps": "0.0.3",
+    "ember-jane-maps": "0.0.5",
     "numeral": "^2.0.6"
   }
 }


### PR DESCRIPTION
This PR

- Temporarily fixes geometry type switching in selection (resets the selection where geometries cannot yet be exploded/imploded)

- Adds geolabels to all geometries

- Upgrades to ember-jane-maps v0.0.5 (deals with a "before" map layer error)