### PR TITLE
Simplify th styles

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -403,6 +403,11 @@ table,
   min-width: 100%;
 }
 
+th {
+  border: 1px solid $medium-gray;
+  vertical-align: bottom;
+}
+
 td:not(:first-child) {
   text-align: right;
 }
@@ -481,17 +486,6 @@ th:first-child {
   td:nth-child(2) {
     border-left: 1px solid $medium-gray;
   }
-}
-
-
-
-th {
-  border-left: 1px solid $medium-gray;
-  vertical-align: bottom;
-}
-
-.cell-border-bottom {
-  border-bottom: 1px solid $medium-gray;
 }
 
 

--- a/app/templates/report/demographic.hbs
+++ b/app/templates/report/demographic.hbs
@@ -26,31 +26,31 @@
 <div class="table-scroll">
   <table class="text-small v-divider-before-7 v-divider-before-2 v-divider-before-12">
     <thead>
-      <tr>
+      <tr class="text-center cell-border-bottom">
         <th class="th-large" rowspan="3">Sex and Age</th>
-        <th colspan="5" class="text-center cell-border-bottom">Selected Area</th>
-        <th colspan="5" class="text-center cell-border-bottom">Comparison Area</th>
-        <th colspan="2" rowspan="2" class="text-center cell-border-bottom">Difference</th>
+        <th colspan="5">Selected Area</th>
+        <th colspan="5">Comparison Area</th>
+        <th colspan="2" rowspan="2">Difference</th>
       </tr>
-      <tr>
-        <th colspan="3" class="text-center cell-border-bottom">Number</th>
-        <th colspan="2" class="text-center cell-border-bottom">Percent</th>
-        <th colspan="3" class="text-center cell-border-bottom">Number</th>
-        <th colspan="2" class="text-center cell-border-bottom">Percent</th>
+      <tr class="text-center cell-border-bottom">
+        <th colspan="3">Number</th>
+        <th colspan="2">Percent</th>
+        <th colspan="3">Number</th>
+        <th colspan="2">Percent</th>
       </tr>
-      <tr>
-        <th class="text-center cell-border-bottom">Estimate</th>
-        <th class="text-center cell-border-bottom">MOE</th>
-        <th class="text-center cell-border-bottom">CV</th>
-        <th class="text-center cell-border-bottom">Estimate</th>
-        <th class="text-center cell-border-bottom">MOE</th>
-        <th class="text-center cell-border-bottom">Estimate</th>
-        <th class="text-center cell-border-bottom">MOE</th>
-        <th class="text-center cell-border-bottom">CV</th>
-        <th class="text-center cell-border-bottom">Estimate</th>
-        <th class="text-center cell-border-bottom">MOE</th>
-        <th class="text-center cell-border-bottom">Number</th>
-        <th class="text-center cell-border-bottom">Pctg. Point</th>
+      <tr class="text-center cell-border-bottom">
+        <th>Estimate</th>
+        <th>MOE</th>
+        <th>CV</th>
+        <th>Estimate</th>
+        <th>MOE</th>
+        <th>Estimate</th>
+        <th>MOE</th>
+        <th>CV</th>
+        <th>Estimate</th>
+        <th>MOE</th>
+        <th>Number</th>
+        <th>Pctg. Point</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
This PR simplifies the styles for table header cells. Since borders collapse, `th` can just have border on all sides, and there's no need for the classes on every single one. 