### PR TITLE
Fix horizontal scroll bug

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -325,7 +325,6 @@ button {
   h1, h2, p, ul {
     max-width: rem-calc(630);
   }
-
 }
 
 .report-menus {

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -43,9 +43,18 @@ body {
   @include breakpoint(large) {
     z-index: 1;
     overflow: hidden;
+  }
 
-    .cell {
-      @include xy-cell-block($vertical:true);
+  .overflow-y-grid {
+
+    @include breakpoint(large) {
+      @include xy-grid(vertical, true);
+      height: calc(100vh - 7.25rem);
+      overflow: hidden;
+
+      > .cell {
+        @include xy-cell-block($vertical:true);
+      }
     }
   }
 }
@@ -181,15 +190,6 @@ body {
 
   @include breakpoint(large) {
     padding-left: 0;
-  }
-}
-
-.overflow-y-grid {
-
-  @include breakpoint(large) {
-    @include xy-grid(vertical, true);
-    height: calc(100vh - 7.25rem);
-    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
Nested grids were causing their parent cell to scroll horizontally. This PR addresses this issue by apply the `xy-cell-block()` mixin only to direct child cells of `.overflow-y-grid`, whereas is was previously/mistakenly applied to all cells in `.site-main`. 