### PR TITLE
Mode switcher as subhead radios

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -188,99 +188,6 @@ button {
 
 
 //
-// Lot Styles
-// --------------------------------------------------
-.lot-section-header {
-  margin: 1rem 0 rem-calc(6);
-}
-
-.lot-zoning-info {
-  font-size: rem-calc(13);
-}
-
-.lot-zoning-list {
-  margin: $paragraph-margin-bottom/2 0;
-  list-style: none;
-
-  li {
-    display: inline-block;
-    vertical-align: middle;
-  }
-
-  .menu-text {
-    font-weight: $global-weight-bold;
-    padding: rem-calc(4) 0;
-  }
-
-  .button {
-    font-size: rem-calc(13);
-    padding: rem-calc(4) rem-calc(6);
-    margin: 0;
-  }
-}
-
-
-//
-// Data Grid
-// --------------------------------------------------
-.data-grid {
-  @include xy-grid;
-  padding: rem-calc(3) 0;
-
-  &:hover {
-    background-color: $light-gray;
-  }
-
-  @include breakpoint(medium) {
-    @include xy-gutters(
-      $gutters: rem-calc(10),
-      $gutter-type: margin,
-      $gutter-position: right left,
-      $negative: true
-    );
-  }
-
-  .data-label {
-    @include xy-cell-static(full,false,0);
-    padding: rem-calc(2) rem-calc(4);
-    background-color: $light-gray;
-    color: $dark-gray;
-    font-size: rem-calc(10);
-    line-height: 1.2;
-
-    @include breakpoint(medium) {
-      @include xy-cell-static(
-        $size: 4,
-        $gutter-output: true,
-        $gutters: rem-calc(10),
-        $gutter-type: margin,
-        $breakpoint: null,
-        $vertical: false
-      );
-    }
-
-  }
-
-  .datum {
-    @include xy-cell-static(full,false,0);
-    font-size: rem-calc(13);
-    line-height: 1.2;
-
-    @include breakpoint(medium) {
-      @include xy-cell-static(
-        $size: 8,
-        $gutter-output: true,
-        $gutters: rem-calc(10),
-        $gutter-type: margin,
-        $breakpoint: null,
-        $vertical: false
-      );
-    }
-  }
-}
-
-
-//
 // Ember Tooltip
 // --------------------------------------------------
 .ember-tooltip {
@@ -294,20 +201,18 @@ button {
 .report-geographies {
   margin-bottom: $global-margin;
   max-width: rem-calc(630);
-  max-height: 6em;
+  max-height: 5.75em;
   overflow: auto;
-  line-height: 1.2;
-
-  .report-geographies-header, .report-geographies-list {
-    font-size: rem-calc(12);
-  }
+  font-size: rem-calc(12);
 
   .report-geographies-header {
     display: inline;
+    font-size: 1rem;
   }
 
   .report-geographies-list {
     display: inline;
+    font-size: rem-calc(12);
   }
 }
 
@@ -316,10 +221,6 @@ button {
 
   h1 {
     margin-bottom: 0.25rem;
-  }
-
-  h2 {
-    margin-bottom: $global-margin;
   }
 
   h1, h2, p, ul {
@@ -343,31 +244,13 @@ button {
 }
 
 .report-mode {
-  font-weight: $global-weight-bold;
-  margin-bottom: $global-margin/2;
-  background-color: $white;
 
-  @include breakpoint(medium) {
-    font-size: rem-calc(10);
-    text-transform: uppercase;
-    float: right;
-    white-space: nowrap;
-    margin-top: rem-calc(-10);
-    border-radius: 4px;
-    overflow: hidden;
-    box-shadow: 0 0 0 2px rgba(0,0,0,0.05);
+  h2 + h2 {
+    margin-top: $global-margin*-0.75;
   }
 
-  .fa {
-  }
-
-  li.active {
-    a {
-      background-color: $primary-color;
-      color: $white;
-      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.06);
-
-    }
+  a {
+    color: inherit;
   }
 }
 

--- a/app/templates/components/report-header.hbs
+++ b/app/templates/components/report-header.hbs
@@ -1,12 +1,33 @@
 <div class="report-header grid-x grid-margin-x">
   <div class="cell medium-9 large-shrink">
 
-    <h1>{{title}}</h1>
-    {{#if subtitle}}
-      <h2 class="header-small dark-gray">{{subtitle}}
-        {{#if subtitleInfo}}<sup>{{fa-icon 'info-circle'}}{{tooltip-on-element text=subtitleInfo}}</sup>{{/if}}
+    <h1>
+      {{title}}
+      <a class='button tiny gray text-orange' {{action 'handleDownload'}}>Download Data <small>(CSV)</small></a>
+    </h1>
+
+    <div class="report-mode">
+      <h2 class="header-medium" class="{{if (eq mode 'change') 'dark-gray'}}">
+        <a {{action (mut mode) 'current'}}>
+          {{#if (eq mode 'current')}}
+            {{fa-icon 'dot-circle-o'}}
+          {{else}}
+            <span class="medium-gray">{{fa-icon 'circle-thin'}}</span>
+          {{/if}}
+          2011-2015 American Community Survey <small>(ACS)</small>
+        </a>
       </h2>
-    {{/if}}
+      <h2 class="header-medium" class="{{if (eq mode 'current') 'dark-gray'}}">
+        <a {{action (mut mode) 'change'}}>
+          {{#if (eq mode 'change')}}
+            {{fa-icon 'dot-circle-o'}}
+          {{else}}
+            <span class="medium-gray">{{fa-icon 'circle-thin'}}</span>
+          {{/if}}
+          Change Over Time <small>(2006-2010 vs 2011-2015)</small>
+        </a>
+      </h2>
+    </div>
 
     <div class="report-geographies">
       <h3 class="report-geographies-header">

--- a/app/templates/report.hbs
+++ b/app/templates/report.hbs
@@ -2,11 +2,6 @@
   <div class="cell shrink">
 
     <div class="report-menus">
-      <ul class="menu report-mode expanded text-center">
-        <li class="{{if (eq mode 'current') 'active'}}"><a {{action (mut mode) 'current'}} {{action (mut scrollTable) true}}>Current</a></li>
-        <li class="{{if (eq mode 'change') 'active'}}"><a {{action (mut mode) 'change'}} {{action (mut scrollTable) true}}>Change <span class="show-for-xlarge">Over Time</span></a></li>
-      </ul>
-
       <ul class="menu tabs vertical medium-horizontal text-center">
         <li>{{link-to 'Census' 'report.census'}}</li>
         {{#if (eq summaryLevel 'blocks')}}
@@ -22,10 +17,6 @@
         {{/if}}
       </ul>
     </div>
-
-    <a class='button small expanded hollow' {{action 'handleDownload'}}>
-      Download this Profile (csv)
-    </a>
 
   </div>
   <div class="cell auto">

--- a/app/templates/report/demographic.hbs
+++ b/app/templates/report/demographic.hbs
@@ -1,14 +1,15 @@
 
 
 {{#report-header
-  title=(if (eq report.mode 'current') "Demographic Profile" "Demographic Profile of Change Over Time")
-  subtitle=(if (eq report.mode 'current') "American Community Survey (ACS), 2011-2015" "American Community Survey (ACS), 2006-2010 to 2011-2015")
-  subtitleInfo="Data associated with estimates of zero, top- and bottom-coded estimates, or Coefficients of Variation (CVs) of 20% or more are grayed out to signify poor statistical reliability. Comparisons and changes over time that are not statistically significant at a 90% confidence level are also grayed out."
+  title="Demographic Profile"
+  mode=report.mode
 }}
-  <p class="dark-gray- text-tiny"><em>
+  <p class="text-tiny">
     ACS data are derived from a survey and are subject to sampling variability.
     Grayed values are not statistically reliable (<a href="https://www.census.gov/programs-surveys/acs/guidance.html" target="_blank">guidance for ACS data</a>).
-  </em></p>
+
+    Data associated with estimates of zero, top- and bottom-coded estimates, or Coefficients of Variation (CVs) of 20% or more are grayed out to signify poor statistical reliability. Comparisons and changes over time that are not statistically significant at a 90% confidence level are also grayed out.
+  </p>
 {{/report-header}}
 
 <ul class="menu report-extras">
@@ -30,7 +31,9 @@
   </a></li>
 </ul>
 
-<h3>Age and Sex</h3>
+<hr>
+
+<h3 class="header-medium">Age and Sex</h3>
 <div class="grid-x grid-margin-x">
   <div class="cell large-8">
     <a class="button small expanded hollow" {{action 'handleCopy'}}>Copy to Clipboard</a>
@@ -53,7 +56,9 @@
   </div>
 </div>
 
-<h3>Mutually Exclusive Race / Hispanic Origin</h3>
+<hr>
+
+<h3 class="header-medium">Mutually Exclusive Race / Hispanic Origin</h3>
 {{#acs-table options=report}}
   {{#each raceGroup as |row|}}
     {{acs-table-row
@@ -65,7 +70,9 @@
   {{/each}}
 {{/acs-table}}
 
-<h3>Hispanic Subgroup</h3>
+<hr>
+
+<h3 class="header-medium">>Hispanic Subgroup</h3>
 {{#acs-table options=report}}
   {{#each hispanicSubgroup as |row|}}
     {{acs-table-row
@@ -77,7 +84,9 @@
   {{/each}}
 {{/acs-table}}
 
-<h3>Asian Subgroup</h3>
+<hr>
+
+<h3 class="header-medium">>Asian Subgroup</h3>
 {{#acs-table reliability=report.reliability comparison=report.comparison scrollTable=report.scrollTable}}
   {{#each asianSubgroup as |row|}}
     {{acs-table-row
@@ -88,8 +97,6 @@
     }}
   {{/each}}
 {{/acs-table}}
-
-
 
 <a class="button tiny hollow expanded" {{action (mut report.scrollTable) (not report.scrollTable)}}>
   {{#if report.scrollTable}}


### PR DESCRIPTION
This PR moves the Current/Change report mode switcher UI into the report header, explicitly stating both modes in subheaders that function as radio buttons. 