### PR TITLE
Revised Selection Layout

### DIFF
--- a/app/components/map-utility-box.js
+++ b/app/components/map-utility-box.js
@@ -11,6 +11,7 @@ export default Ember.Component.extend({
 
   selectionCount: alias('selection.selectedCount'),
   mode: 'direct-select',
+  advanced: false,
 
   summaryLevel: alias('selection.summaryLevel'),
 

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -96,6 +96,17 @@ button {
   }
 }
 
+.view-profile-button {
+  font-size: rem-calc(24) !important;
+  padding: rem-calc(10);
+  line-height: 1.2;
+
+  small {
+    display: block;
+    color: $a11y-yellow;
+  }
+}
+
 .button.text-orange {
   color: $primary-color;
 }

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -493,3 +493,27 @@ tbody td:first-child {
   line-height: 1.2;
   margin-bottom: 0.5rem;
 }
+
+
+//
+// Draw Tool
+// --------------------------------------------------
+.selection-tool--draw {
+  margin: $global-margin 0 0;
+
+  @include breakpoint(medium) {
+    margin-top: 0;
+  }
+
+  &.active, &.button:focus {
+    // @include button-style($primary-color, auto, $white);
+    color: $white;
+    background-color: $primary-color;
+  }
+
+  .fa {
+    display: inline-block;
+    vertical-align: middle;
+    font-size: rem-calc(19);
+  }
+}

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -28,17 +28,7 @@ body {
   position: relative;
   z-index: 2;
   height: calc(100vh - 6rem);
-
-  a {
-    @include breakpoint(small only) {
-      padding-right: 0.75rem;
-      padding-left: 0.75rem;
-    }
-  }
-
-  li:hover {
-    background-color: rgba(0,0,0,0.03);
-  }
+  background-color: $white;
 
   @include breakpoint(large) {
     z-index: 1;
@@ -84,6 +74,17 @@ body {
     li:not(:last-child) {
       border-right: 1px solid rgba(0,0,0,0.1);
     }
+  }
+
+  a {
+    @include breakpoint(small only) {
+      padding-right: 0.75rem;
+      padding-left: 0.75rem;
+    }
+  }
+
+  li:hover {
+    background-color: rgba(0,0,0,0.03);
   }
 }
 
@@ -166,6 +167,26 @@ body {
   .medium-shrink {
     @include breakpoint(medium) {
       padding-left: rem-calc(10);
+    }
+  }
+}
+
+.selection-helpers {
+  transition: all 0.2s;
+
+  &.closed {
+    display: none;
+  }
+
+  @include breakpoint(large) {
+    height: calc(100vh - #{rem-calc(472)});
+    min-height: rem-calc(200);
+    overflow: auto;
+
+    &.closed {
+      display: block;
+      height: 0;
+      min-height: 0;
     }
   }
 }

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -123,7 +123,7 @@ body {
     left: 50px;
     z-index: 4;
     margin-top: rem-calc(92);
-    width: rem-calc(350);
+    width: rem-calc(320);
     box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
   }
 
@@ -152,7 +152,7 @@ body {
   position: relative;
   bottom: 50vh;
   left: -$global-margin;
-  z-index: 1;
+  z-index: 100;
   margin-left: 50px;
 
   @include breakpoint(large) {
@@ -163,22 +163,19 @@ body {
     width: rem-calc(300);
     margin-left: 0;
     margin-top: rem-calc(-92);
-
-    input {
-      margin-bottom: 0;
-    }
-
   }
 }
 
 .selection-tools {
+  margin: 0;
+  padding: 0 0 0 1rem;
 
   @include breakpoint(large) {
-    position: absolute;
-    top: 0;
-    right: auto;
-    left: calc(100% + 10px);
-    z-index: 2;
+    // position: absolute;
+    // top: 0;
+    // right: auto;
+    // left: calc(100% + 10px);
+    // z-index: 2;
   }
 
   button {

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -137,7 +137,6 @@ body {
   }
 
   .button--clear-selection {
-    padding: 0.375rem 0.5rem;
     margin: 0 0 0 $global-margin;
   }
 }

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -132,19 +132,8 @@ body {
   }
 
   .button--clear-selection {
-    padding: 0.375rem;
-
-    @include breakpoint(large) {
-      position: absolute;
-      top: 100%;
-      left: 0;
-      background-color: $white;
-      margin-top: rem-calc(10);
-      box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
-      font-size: rem-calc(12);
-      padding: 0.75em 0.875em;
-      border-radius: 4px;
-    }
+    padding: 0.375rem 0.5rem;
+    margin: 0 0 0 $global-margin;
   }
 }
 
@@ -154,6 +143,7 @@ body {
   left: -$global-margin;
   z-index: 100;
   margin-left: 50px;
+  margin-bottom: rem-calc(-40);
 
   @include breakpoint(large) {
     position: absolute;
@@ -166,37 +156,12 @@ body {
   }
 }
 
-.selection-tools {
-  margin: 0;
-  padding: 0 0 0 1rem;
+.call-to-action {
+  margin-bottom: $global-margin;
 
-  @include breakpoint(large) {
-    // position: absolute;
-    // top: 0;
-    // right: auto;
-    // left: calc(100% + 10px);
-    // z-index: 2;
-  }
-
-  button {
-    @include button(false, $white, #f2f2f2, $primary-color, solid);
-    border-radius: 4px;
-    white-space: nowrap;
-    font-size: rem-calc(12);
-    padding: rem-calc(6) rem-calc(10) rem-calc(5) rem-calc(8);
-
-    @include breakpoint(large) {
-      box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
-    }
-
-    &.active {
-      @include button-style($primary-color, auto, $white);
-    }
-
-    .fa {
-      display: inline-block;
-      vertical-align: middle;
-      font-size: rem-calc(19);
+  .medium-shrink {
+    @include breakpoint(medium) {
+      padding-left: rem-calc(10);
     }
   }
 }

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -70,8 +70,8 @@ body {
 
   @include breakpoint(large) {
     position: absolute;
-    top: 20px;
-    left: 60px;
+    top: rem-calc(58);
+    left: 50px;
     background-color: $light-gray;
     border-radius: 4px;
     box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
@@ -119,10 +119,10 @@ body {
 
   @include breakpoint(large) {
     position: absolute;
-    top: 40px;
-    left: 60px;
-    z-index: 2;
-    margin-top: rem-calc(24);
+    top: 10px;
+    left: 50px;
+    z-index: 4;
+    margin-top: rem-calc(92);
     width: rem-calc(350);
     box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
   }
@@ -145,6 +145,29 @@ body {
       padding: 0.75em 0.875em;
       border-radius: 4px;
     }
+  }
+}
+
+.search {
+  position: relative;
+  bottom: 50vh;
+  left: -$global-margin;
+  z-index: 1;
+  margin-left: 50px;
+
+  @include breakpoint(large) {
+    position: absolute;
+    top: 0;
+    bottom: auto;
+    left: 0;
+    width: rem-calc(300);
+    margin-left: 0;
+    margin-top: rem-calc(-92);
+
+    input {
+      margin-bottom: 0;
+    }
+
   }
 }
 

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -37,6 +37,10 @@
   }
 }
 
+.mapboxgl-ctrl-group > button {
+  border-radius: 0;
+}
+
 .find-me {
   position: absolute;
   top: 108px;

--- a/app/styles/modules/_m-search.scss
+++ b/app/styles/modules/_m-search.scss
@@ -3,10 +3,6 @@
 // --------------------------------------------------
 
 .search {
-  position: relative;
-  z-index: 1;
-
-  input {}
 
   .close-button {
     margin-top: rem-calc(-7);

--- a/app/styles/modules/_m-search.scss
+++ b/app/styles/modules/_m-search.scss
@@ -4,8 +4,14 @@
 
 .search {
 
+  input {
+    margin-bottom: 0;
+    padding-right: 2.2rem;
+  }
+
   .close-button {
-    margin-top: rem-calc(-7);
+    margin-top: rem-calc(-6);
+    right: rem-calc(10);
   }
 
   .search-icon {

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -1,10 +1,5 @@
 {{#if (eq mode 'direct-select')}}
 
-  {{!-- <div class="search hide-for-print ember-view">
-    <input type="text" placeholder="Search..." id="ember438" class="map-search-input ember-text-field ember-view">
-    <span class="search-icon">{{fa-icon 'search'}}</span>
-  </div> --}}
-
   {{map-search transitionTo=(action 'transitionTo')}}
 
   <div class="grid-x grid-margin-x align-middle">
@@ -36,7 +31,6 @@
   {{#link-to 'profile' class=profileButtonClasses}}{{fa-icon 'file-text'}}&nbsp;View Profile{{/link-to}}
 
   <a href="#" class="button small expanded gray text-orange">{{fa-icon 'sliders'}}&nbsp;Advanced Options</a>
-
 
   {{yield}}
 

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -32,11 +32,19 @@
     </strong></small>
   {{/link-to}}
 
-  {{#if (gt selectionCount 0)}}
-    <button {{action "clearSelection"}} class="button--clear-selection button tiny gray float-right"><span class="lu-red">{{fa-icon 'times'}}</span> Clear Selection</button>
-  {{/if}}
+  <div class="clearfix">
+    {{#if (gt selectionCount 0)}}
+      <button {{action "clearSelection"}} class="button--clear-selection button tiny gray float-right"><span class="lu-red">{{fa-icon 'times'}}</span> Clear Selection</button>
+    {{/if}}
 
-  <a class="text-small">{{fa-icon 'sliders'}}&nbsp;Advanced Options</a>
+    <a {{action (mut advanced) (not advanced)}} class="text-small">{{fa-icon 'sliders'}}&nbsp;Advanced Options</a>
+  </div>
+
+  <div class="selection-helpers {{unless advanced 'closed'}}">
+    <p>foo</p><p>foo</p><p>foo</p><p>foo</p><p>foo</p>
+    <p>foo</p><p>foo</p><p>foo</p><p>foo</p><p>foo</p>
+    <p>foo</p><p>foo</p><p>foo</p><p>foo</p><p>foo</p>
+  </div>
 
   {{yield}}
 

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -2,38 +2,41 @@
 
   {{map-search transitionTo=(action 'transitionTo')}}
 
-  <div class="grid-x grid-margin-x align-middle">
-    <div class="cell medium-6 text-center">
-      <strong class="stat">
-        {{selectionCount}}
-      </strong>
-      <p class="dark-gray">
-        <strong>
-          {{if (eq summaryLevel 'tracts') 'Tract'~}}
-          {{if (eq summaryLevel 'blocks') 'Block'~}}
-          {{if (eq summaryLevel 'ntas') 'Neighborhood'~}}
-          {{if (eq summaryLevel 'pumas') 'PUMA'~}}
-          {{if (eq selectionCount 0) 's'}}{{if (gt selectionCount 1) 's'}}
-        </strong>
-      </p>
-      {{#if (gt selectionCount 0)}}
-        <button {{action "clearSelection"}} class="button--clear-selection button tiny gray"><span class="lu-red">{{fa-icon 'times'}}</span>&nbsp;Clear Selection</button>
-      {{/if}}
-    </div>
-    <div class="cell medium-6">
-      <p class="text-small dark-gray">{{fa-icon 'hand-pointer-o'}}&nbsp;Select individual 
+  <div class="grid-x align-middle text-center medium-text-left">
+    <div class="cell medium-auto">
+      <p class="text-small dark-gray">{{fa-icon 'hand-pointer-o'}}&nbsp;Select individual
         {{if (eq summaryLevel 'tracts') 'census tracts'}}
         {{if (eq summaryLevel 'blocks') 'census blocks'}}
         {{if (eq summaryLevel 'ntas') 'NTAs'}}
         {{if (eq summaryLevel 'pumas') 'PUMAs'}}
         to add them to the profile.</p>
+    </div>
+    <div class="cell medium-shrink">
       <ul class="selection-tools no-bullet">
         <button class="selection-tool--draw {{if drawMode 'active'}}" {{action "handleDrawButtonClick"}}>{{fa-icon "pencil-square-o"}} Draw</button>
       </ul>
     </div>
   </div>
 
-  {{#link-to 'profile' class=profileButtonClasses}}{{fa-icon 'file-text'}}&nbsp;View Profile{{/link-to}}
+  {{#if (gt selectionCount 0)}}
+    <button {{action "clearSelection"}} class="button--clear-selection button tiny gray"><span class="lu-red">{{fa-icon 'times'}}</span>&nbsp;Clear Selection</button>
+  {{/if}}
+
+  {{#link-to 'profile' class=profileButtonClasses}}
+    <span class="fa-stack fa-pull-right">
+      {{fa-icon 'file' class='fa-stack-2x'}}
+      {{fa-icon 'arrow-right' class='fa-stack-1x dcp-yellow'}}
+    </span>
+    <small>View Profile</small>
+    <strong>
+      {{selectionCount}}
+      {{if (eq summaryLevel 'tracts') 'Tract'~}}
+      {{if (eq summaryLevel 'blocks') 'Block'~}}
+      {{if (eq summaryLevel 'ntas') 'Neighborhood'~}}
+      {{if (eq summaryLevel 'pumas') 'PUMA'~}}
+      {{if (eq selectionCount 0) 's'}}{{if (gt selectionCount 1) 's'}}
+    </strong>
+  {{/link-to}}
 
   <a href="#" class="button small expanded gray text-orange">{{fa-icon 'sliders'}}&nbsp;Advanced Options</a>
 

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -23,7 +23,7 @@
     </span>
     <small>View Profile</small>
     <strong>
-      {{selectionCount}}
+      <span class="count">{{selectionCount}}</span>
       {{if (eq summaryLevel 'tracts') 'Tract'~}}
       {{if (eq summaryLevel 'blocks') 'Block'~}}
       {{if (eq summaryLevel 'ntas') 'Neighborhood'~}}

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -2,9 +2,9 @@
 
   {{map-search transitionTo=(action 'transitionTo')}}
 
-  <div class="grid-x align-middle text-center medium-text-left">
+  <div class="call-to-action grid-x align-middle text-center medium-text-left">
     <div class="cell medium-auto">
-      <p class="text-small dark-gray">{{fa-icon 'hand-pointer-o'}}&nbsp;Select individual
+      <p class="text-small dark-gray no-margin">{{fa-icon 'hand-pointer-o'}}&nbsp;Select individual
         {{if (eq summaryLevel 'tracts') 'census tracts'}}
         {{if (eq summaryLevel 'blocks') 'census blocks'}}
         {{if (eq summaryLevel 'ntas') 'NTAs'}}
@@ -12,15 +12,9 @@
         to add them to the profile.</p>
     </div>
     <div class="cell medium-shrink">
-      <ul class="selection-tools no-bullet">
-        <button class="selection-tool--draw {{if drawMode 'active'}}" {{action "handleDrawButtonClick"}}>{{fa-icon "pencil-square-o"}} Draw</button>
-      </ul>
+      <button class="selection-tool--draw button small gray text-orange {{if drawMode 'active'}}" {{action "handleDrawButtonClick"}}>{{fa-icon "pencil-square-o"}} Draw</button>
     </div>
   </div>
-
-  {{#if (gt selectionCount 0)}}
-    <button {{action "clearSelection"}} class="button--clear-selection button tiny gray"><span class="lu-red">{{fa-icon 'times'}}</span>&nbsp;Clear Selection</button>
-  {{/if}}
 
   {{#link-to 'profile' class=profileButtonClasses}}
     <span class="fa-stack fa-pull-right">
@@ -38,7 +32,11 @@
     </strong>
   {{/link-to}}
 
-  <a href="#" class="button small expanded gray text-orange">{{fa-icon 'sliders'}}&nbsp;Advanced Options</a>
+  {{#if (gt selectionCount 0)}}
+    <button {{action "clearSelection"}} class="button--clear-selection button small gray float-right"><span class="lu-red">{{fa-icon 'times'}}</span>&nbsp;Clear</button>
+  {{/if}}
+
+  <a class="text-small">{{fa-icon 'sliders'}}&nbsp;Advanced Options</a>
 
   {{yield}}
 

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -21,19 +21,19 @@
       {{fa-icon 'file' class='fa-stack-2x'}}
       {{fa-icon 'arrow-right' class='fa-stack-1x dcp-yellow'}}
     </span>
-    <small>View Profile</small>
-    <strong>
+    View Profile
+    <small><strong>
       <span class="count">{{selectionCount}}</span>
       {{if (eq summaryLevel 'tracts') 'Tract'~}}
       {{if (eq summaryLevel 'blocks') 'Block'~}}
       {{if (eq summaryLevel 'ntas') 'Neighborhood'~}}
       {{if (eq summaryLevel 'pumas') 'PUMA'~}}
       {{if (eq selectionCount 0) 's'}}{{if (gt selectionCount 1) 's'}}
-    </strong>
+    </strong></small>
   {{/link-to}}
 
   {{#if (gt selectionCount 0)}}
-    <button {{action "clearSelection"}} class="button--clear-selection button small gray float-right"><span class="lu-red">{{fa-icon 'times'}}</span>&nbsp;Clear</button>
+    <button {{action "clearSelection"}} class="button--clear-selection button tiny gray float-right"><span class="lu-red">{{fa-icon 'times'}}</span> Clear Selection</button>
   {{/if}}
 
   <a class="text-small">{{fa-icon 'sliders'}}&nbsp;Advanced Options</a>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -29,8 +29,6 @@
       {{/map.source}}
     {{/if}}
 
-
-
     {{#if selection.searchResultFeature}}
       {{#map.source sourceId='searchResultSource' options=selection.searchResultSource as |source|}}
         {{source.layer layer=selection.searchResultLayer}}
@@ -46,7 +44,6 @@
     {{map.layer-group config=layerGroups.neighborhoodTabulationAreas visible=(eq selection.summaryLevel 'ntas')}}
 
     {{map.layer-group config=layerGroups.nycPumas visible=(eq selection.summaryLevel 'pumas')}}
-
 
     {{#if selection.current}}
       {{#map.source

--- a/tests/acceptance/select-geometries-test.js
+++ b/tests/acceptance/select-geometries-test.js
@@ -29,7 +29,7 @@ test('visiting /', async function(assert) {
 test('visiting /, see no tracks selected', async function(assert) {
   await visit('/');
 
-  assert.equal($(find('.map-utility-box .stat')).text().trim(), '0');
+  assert.equal($(find('.map-utility-box .count')).text().trim(), '0');
 });
 
 test('visiting /, adds tracts, counts number of tracts, explodes tracts to blocks', async function(assert) {
@@ -38,10 +38,9 @@ test('visiting /, adds tracts, counts number of tracts, explodes tracts to block
     indexController.get('selection').handleSelectedFeatures(config.SAMPLE_SELECTION.features);
   });
 
-  assert.equal($(find('.map-utility-box .stat')).text().trim(), '5');
+  assert.equal($(find('.map-utility-box .count')).text().trim(), '5');
 
   await click('.explode-block a');
-  await waitUntil(() => ($(find('.map-utility-box .stat')).text().trim()) !== '5', { timeout: 5000 });
-  assert.equal($(find('.map-utility-box .stat')).text().trim(), '113');
+  await waitUntil(() => ($(find('.map-utility-box .count')).text().trim()) !== '5', { timeout: 5000 });
+  assert.equal($(find('.map-utility-box .count')).text().trim(), '113');
 });
-


### PR DESCRIPTION
In preparation for adding the "Advanced Options" to the selection route (@chriswhong is working on filters), I've rethought the layout. This PR… 

- moves search out of the selection overview box, as it's a separate action from making a selection
- combines the selection count and "view selection" button into one frickin' sweet button
- finds a better place for the "clear selection" button, moving it into the box
- restyles the "Advanced Options" button
- makes all of this work MUCH better on small screens 
- closes #219 

New layout (left) vs old layout (right)
 
![image](https://user-images.githubusercontent.com/409279/33357623-32aecd0c-d491-11e7-94de-c6f81c126b0c.png)
