### PR TITLE
add lastreport query param

### DIFF
--- a/app/components/map-utility-box.js
+++ b/app/components/map-utility-box.js
@@ -11,6 +11,7 @@ const { SupportServiceHost } = Environment;
 export default Ember.Component.extend({
   selection: service(),
   router: service(),
+  lastreport: null,
 
   classNames: ['map-utility-box'],
 
@@ -40,8 +41,11 @@ export default Ember.Component.extend({
     })
       .then(d => d.json());
 
+    const lastreport = this.get('lastreport');
+    const transitionRoute = `profile.${lastreport}`;
+
     yield this.get('router')
-      .transitionTo('profile', id, { queryParams: { mode: 'current', comparator: '0' } });
+      .transitionTo(transitionRoute, id, { queryParams: { mode: 'current', comparator: '0' } });
   }).restartable(),
 
   actions: {

--- a/app/components/profile-header.js
+++ b/app/components/profile-header.js
@@ -14,6 +14,11 @@ export default Ember.Component.extend({
 
   selection: service(),
 
+  @computed()
+  currentProfile() {
+    return this.get('profile').target.currentRouteName.split('.')[1];
+  },
+
   sources,
   zoom: 10,
   center: [-73.916016, 40.697299],

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -29,6 +29,9 @@ const draw = new MapboxDraw({
 });
 
 export default Ember.Controller.extend({
+  queryParams: ['lastreport'],
+  lastreport: 'demographic',
+
   selection: service(),
   mapMouseover: service(),
 

--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>LabsNycFactfinder</title>
+    <title>NYC Population Factfinder</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/templates/components/profile-header.hbs
+++ b/app/templates/components/profile-header.hbs
@@ -132,7 +132,7 @@
 
         {{map.on 'resize' (action 'handleResize')}}
       {{/mapbox-gl}}
-      {{#link-to 'index' classNames='edit-selection-button button tiny white text-orange'}}{{fa-icon 'pencil'}}&nbsp;Edit&nbsp;Selection{{/link-to}}
+      {{#link-to 'index' (query-params lastreport=currentProfile) classNames='edit-selection-button button tiny white text-orange'}}{{fa-icon 'pencil'}}&nbsp;Edit&nbsp;Selection{{/link-to}}
     </div>
 
  </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -74,7 +74,6 @@
 
   {{/jane-maps}}
 </div>
-
-{{map-utility-box mode=mode drawMode=drawMode handleDrawButtonClick=(action "handleDrawButtonClick")}}
+{{map-utility-box lastreport=lastreport mode=mode drawMode=drawMode handleDrawButtonClick=(action "handleDrawButtonClick")}}
 
 {{outlet}}


### PR DESCRIPTION
Adds a `lastreport` queryparam to `index` route which indicates the default tab when the user clicks "View report"
Clicking the "Edit Selection" from a report will load `index` with the respective `lastreport` param.

Closes #194