### PR TITLE
fix parks draw selection bug

### DIFF
--- a/app/queries/intersection.js
+++ b/app/queries/intersection.js
@@ -2,7 +2,7 @@ import summaryLevels from '../queries/summary-levels';
 
 const Intersection = (summaryLevel, geometry) => {
   const sqlBase = summaryLevels[summaryLevel](false);
-  return `${sqlBase} WHERE ST_Intersects(the_geom, ST_GeomFromGeoJSON('${JSON.stringify(geometry)}'))`;
+  return `SELECT * FROM (${sqlBase}) base WHERE ST_Intersects(the_geom, ST_GeomFromGeoJSON('${JSON.stringify(geometry)}'))`;
 };
 
 export default Intersection;

--- a/app/queries/summary-levels.js
+++ b/app/queries/summary-levels.js
@@ -31,5 +31,6 @@ export default {
       ntacode as geolabel,
       ntacode AS geoid
     FROM support_admin_ntaboundaries
+    WHERE ntaname NOT ILIKE 'park-cemetery-etc%25'
   `,
 };


### PR DESCRIPTION
Fixes bug where using the draw tool on NTAs will select parks/cemeteries (non-nta spaces citywide).  Updates the query used to intersect with the drawn geometry to exclude the non-ntas.

Closes #133