### PR TITLE
Fix occupation 06-10 data in table

### DIFF
--- a/app/templates/profile/economic.hbs
+++ b/app/templates/profile/economic.hbs
@@ -66,7 +66,7 @@
       comparison=profile.comparison
       config=occupation
       t1=model.y2011_2015.occupation
-      t2=model.y2006_2010.occupatione
+      t2=model.y2006_2010.occupation
     }}
   </div>
   <div class="cell large-4">


### PR DESCRIPTION
Seemed to be an extra letter in the coding for the 2006-2010 occupation label. I think this may fix the problem of the data not appearing.