### PR TITLE
addressed issue 122, 148, 149, 155, 186, 261

### DIFF
--- a/app/templates/components/acs-table-row.hbs
+++ b/app/templates/components/acs-table-row.hbs
@@ -145,7 +145,7 @@
 
     <td>{{rowconfig.title}}</td>
       {{#unless comparison}}
-        <td class="cell-border-left">
+        <td class="cell-border-left"><!--previous dataset sum-->
         {{#if data2.sum}}
           {{numeral-format data2.sum}}
         {{else if (eq data2.sum 0)}}
@@ -154,7 +154,7 @@
            &nbsp;
         {{/if}}
       </td>
-      <td>
+      <td><!--previous dataset percent-->
         {{#if data2.sum}}
           {{#if data2.percent}}
             {{numeral-format data2.percent '0.0%'}}
@@ -167,7 +167,7 @@
           &nbsp;
         {{/if}}
       </td>
-      <td class="cell-border-left">
+      <td class="cell-border-left"><!--current dataset sum-->
         {{#if data2.sum}}
           {{#if data.sum}}
             {{numeral-format data.sum}}
@@ -188,7 +188,7 @@
           &nbsp;
         {{/if}}
       </td>
-      <td>
+      <td><!--current dataset percent-->
         {{#if data2.sum}}
           {{#if data.sum}}
             {{#if data.percent}}
@@ -218,7 +218,7 @@
         {{/if}}
       </td>
     {{/unless}}
-    <td class="cell-border-left">
+    <td class="cell-border-left"><!--selected area sum change-->
       {{#if data2.sum}}
         {{numeral-format (sub data.sum data2.sum) '0,0'}}
       {{else if (eq data2.sum 0)}}
@@ -228,15 +228,17 @@
       {{/if}}
     </td>
     {{#if reliability}}
-    <td>
+    <td><!--selected area sum change moe-->
       {{#if data2.sum}}
+        {{numeral-format (sqrt (add (pow (div data2.m 1.645) 2) (pow (div data.m 1.645) 2))) '0,0'}}
+      {{else if (eq data2.sum 0)}}
         {{numeral-format (sqrt (add (pow (div data2.m 1.645) 2) (pow (div data.m 1.645) 2))) '0,0'}}
       {{else}}
         &nbsp;
       {{/if}}
     </td>
     {{/if}}
-    <td>
+    <td><!--selected area percent change-->
       {{#if data2.sum}}
         {{#if data2.percent}}
           {{numeral-format (div (sub data.sum data2.sum) data2.sum) '0.0%'}}
@@ -250,7 +252,7 @@
       {{/if}}
     </td>
     {{#if reliability}}
-    <td>
+    <td><!--selected area percent change moe-->
       {{#if data2.sum}}
         {{numeral-format longitudinalPercentMOE '0.0%'}}
       {{else}}
@@ -260,7 +262,7 @@
     </td>
     {{/if}}
     {{#if comparison}}
-    <td class="cell-border-left">
+    <td class="cell-border-left"><!--comparison area sum change-->
       {{#if data2.comparison_sum}}
         {{numeral-format (sub data.comparison_sum data2.comparison_sum) '0,0'}}
       {{else if (eq data2.comparison_sum 0)}}
@@ -270,7 +272,7 @@
       {{/if}}
     </td>
     {{#if reliability}}
-    <td>
+    <td><!--comparison area sum change moe-->
       {{#if data2.comparison_sum}}
         {{numeral-format (sqrt (add (pow (div data2.comparison_m 1.645) 2) (pow (div data.comparison_m 1.645) 2))) '0,0'}}
       {{else if (eq data2.comparison_sum 0)}}
@@ -280,7 +282,7 @@
       {{/if}}
     </td>
     {{/if}}
-    <td>
+    <td><!--comparison area percent change-->
       {{#if data2.comparison_sum}}
         {{#if data2.comparison_percent}}
           {{numeral-format (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum) '0.0%'}}
@@ -292,7 +294,7 @@
       {{else}}
         &nbsp;
       {{/if}}
-    </td>
+    </td><!--comparison area percent change moe-->
     {{#if reliability}}
       <td>
       {{#if data2.sum}}
@@ -307,6 +309,8 @@
       <td class="cell-border-left">
         {{#if data2.sum}}
           {{numeral-format (sub (sub data.sum data2.sum) (sub data.comparison_sum data2.comparison_sum)) '0,0'}}
+        {{else if (eq data2.sum 0)}}
+          {{numeral-format (sub (sub data.sum data2.sum) (sub data.comparison_sum data2.comparison_sum)) '0,0'}}
         {{else}}
           &nbsp;
         {{/if}}
@@ -314,6 +318,8 @@
       {{#if reliability}}
         <td>
         {{#if data2.sum}}
+          {{numeral-format differenceMOE '0,0'}}
+        {{else if (eq data2.sum 0)}}
           {{numeral-format differenceMOE '0,0'}}
         {{else}}
           &nbsp;
@@ -329,6 +335,14 @@
           {{else}}
              &nbsp;
           {{/if}}
+        {{else if (eq data2.sum 0)}}
+          {{#if data2.percent}}
+            {{numeral-format (mult (sub (div (sub data.sum data2.sum) data2.sum) (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum)) 100) '0.0'}}
+          {{else if (eq data2.percent 0)}}
+            {{numeral-format (mult (sub (div (sub data.sum data2.sum) data2.sum) (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum)) 100) '0.0'}}
+          {{else}}
+             &nbsp;
+          {{/if}}
         {{else}}
           &nbsp;
         {{/if}}
@@ -336,6 +350,8 @@
       {{#if reliability}}
       <td>
         {{#if data2.sum}}
+          {{numeral-format differencePercentMOE '0.0%'}}
+        {{else if (eq data2.sum 0)}}
           {{numeral-format differencePercentMOE '0.0%'}}
         {{else}}
           &nbsp;

--- a/app/templates/components/acs-table-row.hbs
+++ b/app/templates/components/acs-table-row.hbs
@@ -296,8 +296,10 @@
     {{#if reliability}}
       <td>
       {{#if data2.sum}}
-          {{numeral-format comparisonLongitudinalPercentMOE '0.0%'}}
-        {{else}}
+        {{numeral-format comparisonLongitudinalPercentMOE '0.0%'}}
+      {{else if (eq data2.sum 0)}}
+        {{numeral-format comparisonLongitudinalPercentMOE '0.0%'}}
+      {{else}}
           &nbsp;
         {{/if}}
       </td>

--- a/app/templates/components/acs-table-row.hbs
+++ b/app/templates/components/acs-table-row.hbs
@@ -28,25 +28,77 @@
     <td>{{rowconfig.title}}</td>
     <td class="cell-border-left">{{numeral-format data.sum}}</td>
     {{#if reliability}}
-      <td>{{numeral-format data.m}}</td>
-      <td>{{numeral-format data.cv '0.0'}}</td>
+      <td>
+        {{#if data.sum}}
+          {{numeral-format data.m}}
+        {{else if (eq data.sum 0)}}
+          &nbsp;
+        {{/if}}
+      </td>
+      <td>
+        {{#if data.sum}}
+          {{numeral-format data.cv '0.0'}}
+        {{else if (eq data.sum 0)}}
+          &nbsp;
+        {{/if}}
+      </td>
     {{/if}}
-    <td>{{numeral-format data.percent '0.0%'}}</td>
+    <td>
+      {{#if data.sum}}
+        {{numeral-format data.percent '0.0%'}}
+      {{else if (eq data.sum 0)}}
+        &nbsp;
+      {{/if}}
+    </td>
     {{#if reliability}}
-        <td>{{numeral-format data.percent_m '0.0%'}}</td>
+        <td>
+          {{#if data.sum}}
+            {{numeral-format data.percent_m '0.0%'}}
+          {{else if (eq data.sum 0)}}
+            &nbsp;
+          {{/if}}
+        </td>
     {{/if}}
     {{#if comparison}}
       <td class="cell-border-left">{{numeral-format data.comparison_sum}}</td>
       {{#if reliability}}
-        <td>{{numeral-format data.comparison_m}}</td>
-        <td>{{numeral-format data.comparison_cv '0.0'}}</td>
+        <td>
+          {{#if data.comparison_sum}}
+            {{numeral-format data.comparison_m}}
+          {{else if (eq data.comparison_sum 0)}}
+            &nbsp;
+          {{/if}}
+        </td>
+        <td>
+          {{#if data.comparison_sum}}
+            {{numeral-format data.comparison_cv '0.0'}}
+          {{else if (eq data.comparison_sum 0)}}
+            &nbsp;
+          {{/if}}
+        </td>
       {{/if}}
-      <td>{{numeral-format data.comparison_percent '0.0%'}}</td>
+      <td>
+        {{#if data.comparison_sum}}
+          {{numeral-format data.comparison_percent '0.0%'}}
+        {{else if (eq data.comparison_sum 0)}}
+          &nbsp;
+        {{/if}}
+      </td>
       {{#if reliability}}
-          <td>{{numeral-format data.comparison_percent_m '0.0%'}}</td>
+          <td>
+            {{#if data.comparison_sum}}
+              {{numeral-format data.comparison_percent_m '0.0%'}}
+            {{else if (eq data.comparison_sum 0)}}
+              &nbsp;
+            {{/if}}
+          </td>
       {{/if}}
-      <td class="cell-border-left {{unless data.significant 'medium-gray'}}">{{numeral-format (sub  data.sum data.comparison_sum) '+0,0'}}</td>
-      <td class="{{unless data.percent_significant 'medium-gray'}}">{{numeral-format (mult (sub  data.percent data.comparison_percent)  100)'+0.0'}}</td>
+      <td class="cell-border-left {{unless data.significant 'medium-gray'}}">
+        {{numeral-format (sub  data.sum data.comparison_sum) '0,0'}}
+      </td>
+      <td class="{{unless data.percent_significant 'medium-gray'}}">
+        {{numeral-format (mult (sub  data.percent data.comparison_percent)  100)'0.0'}}
+      </td>
 
     {{/if}}
   {{/if}}
@@ -56,10 +108,12 @@
   {{#if rowconfig.divider}}
 
     <td>&nbsp;</td>
-    <td class="cell-border-left">&nbsp;</td>
-    <td>&nbsp;</td>
-    <td class="cell-border-left">&nbsp;</td>
-    <td>&nbsp;</td>
+    {{#unless comparison}}
+      <td class="cell-border-left">&nbsp;</td>
+      <td>&nbsp;</td>
+      <td class="cell-border-left">&nbsp;</td>
+      <td>&nbsp;</td>
+    {{/unless}}
     <td class="cell-border-left">&nbsp;</td>
     {{#if reliability}}
       <td>&nbsp;</td>
@@ -90,79 +144,117 @@
   {{else}}{{! subheader && divider = false }}
 
     <td>{{rowconfig.title}}</td>
+      {{#unless comparison}}
+        <td class="cell-border-left">
+        {{#if data2.sum}}
+          {{numeral-format data2.sum}}
+        {{else if (eq data2.sum 0)}}
+          {{numeral-format data2.sum}}
+        {{else}}
+           &nbsp;
+        {{/if}}
+      </td>
+      <td>
+        {{#if data2.sum}}
+          {{#if data2.percent}}
+            {{numeral-format data2.percent '0.0%'}}
+          {{else if (eq data2.percent 0)}}
+            {{numeral-format data2.percent '0.0%'}}
+          {{else}}
+            &nbsp;
+          {{/if}}
+        {{else if (eq data2.sum 0)}}
+          &nbsp;
+        {{/if}}
+      </td>
+      <td class="cell-border-left">
+        {{#if data2.sum}}
+          {{#if data.sum}}
+            {{numeral-format data.sum}}
+          {{else if (eq data.sum 0)}}
+            {{numeral-format data.sum}}
+          {{else}}
+            &nbsp;
+          {{/if}}
+        {{else if (eq data2.sum 0)}}
+          {{#if data.sum}}
+            {{numeral-format data.sum}}
+          {{else if (eq data.sum 0)}}
+            {{numeral-format data.sum}}
+          {{else}}
+            &nbsp;
+        {{/if}}
+        {{else}}
+          &nbsp;
+        {{/if}}
+      </td>
+      <td>
+        {{#if data2.sum}}
+          {{#if data.sum}}
+            {{#if data.percent}}
+              {{numeral-format data.percent '0.0%'}}
+            {{else if (eq data.percent 0)}}
+              {{numeral-format data.percent '0.0%'}}
+            {{else}}
+              &nbsp;
+            {{/if}}
+          {{else if (eq data.sum 0)}}
+            &nbsp;
+          {{/if}}
+        {{else if (eq data2.sum 0)}}
+          {{#if data.sum}}
+            {{#if data.percent}}
+              {{numeral-format data.percent '0.0%'}}
+            {{else if (eq data.percent 0)}}
+              {{numeral-format data.percent '0.0%'}}
+            {{else}}
+              &nbsp;
+            {{/if}}
+          {{else if (eq data.sum 0)}}
+            &nbsp;
+          {{/if}}
+        {{else}}
+          &nbsp;
+        {{/if}}
+      </td>
+    {{/unless}}
     <td class="cell-border-left">
       {{#if data2.sum}}
-        {{numeral-format data2.sum}}
+        {{numeral-format (sub data.sum data2.sum) '0,0'}}
       {{else if (eq data2.sum 0)}}
-        {{numeral-format data2.sum}}
+        {{numeral-format (sub data.sum data2.sum) '0,0'}}
       {{else}}
-        n/a
-      {{/if}}
-    </td>
-    <td>
-      {{#if data2.percent}}
-        {{numeral-format data2.percent '0.0%'}}
-      {{else if (eq data2.percent 0)}}
-        {{numeral-format data2.percent '0.0%'}}
-      {{else}}
-        n/a
-      {{/if}}
-    </td>
-    <td class="cell-border-left">
-      {{#if data.sum}}
-        {{numeral-format data.sum}}
-      {{else if (eq data.sum 0)}}
-        {{numeral-format data.sum}}
-      {{else}}
-        n/a
-      {{/if}}
-    </td>
-    <td>
-      {{#if data.percent}}
-        {{numeral-format data.percent '0.0%'}}
-      {{else if (eq data.percent 0)}}
-        {{numeral-format data.percent '0.0%'}}
-      {{else}}
-        n/a
-      {{/if}}
-    </td>
-    <td class="cell-border-left">
-      {{#if data2.sum}}
-        {{numeral-format (sub data.sum data2.sum) '+0,0'}}
-      {{else if (eq data2.sum 0)}}
-        {{numeral-format (sub data.sum data2.sum) '+0,0'}}
-      {{else}}
-        n/a
+        &nbsp;
       {{/if}}
     </td>
     {{#if reliability}}
     <td>
       {{#if data2.sum}}
-        {{numeral-format (sqrt (add (pow (div data2.m 1.645) 2) (pow (div data.m 1.645) 2))) '+0,0'}}
-      {{else if (eq data2.sum 0)}}
-        {{numeral-format (sqrt (add (pow (div data2.m 1.645) 2) (pow (div data.m 1.645) 2))) '+0,0'}}
+        {{numeral-format (sqrt (add (pow (div data2.m 1.645) 2) (pow (div data.m 1.645) 2))) '0,0'}}
       {{else}}
-        n/a
+        &nbsp;
       {{/if}}
     </td>
     {{/if}}
     <td>
-      {{#if data2.percent}}
-        {{numeral-format (div (sub data.sum data2.sum) data2.sum) '+0.0%'}}
-      {{else if (eq data2.percent 0)}}
-        {{numeral-format (div (sub data.sum data2.sum) data2.sum) '+0.0%'}}
-      {{else}}
-        n/a
+      {{#if data2.sum}}
+        {{#if data2.percent}}
+          {{numeral-format (div (sub data.sum data2.sum) data2.sum) '0.0%'}}
+        {{else if (eq data2.percent 0)}}
+          {{numeral-format (div (sub data.sum data2.sum) data2.sum) '0.0%'}}
+        {{else}}
+          &nbsp;
+        {{/if}}
+      {{else if (eq data2.sum 0)}}
+        &nbsp;
       {{/if}}
     </td>
     {{#if reliability}}
     <td>
       {{#if data2.sum}}
-        {{numeral-format longitudinalPercentMOE '+0.0%'}}
-      {{else if (eq data2.sum 0)}}
-        {{numeral-format longitudinalPercentMOE '+0.0%'}}
+        {{numeral-format longitudinalPercentMOE '0.0%'}}
       {{else}}
-        n/a
+        &nbsp;
       {{/if}}
 
     </td>
@@ -170,81 +262,81 @@
     {{#if comparison}}
     <td class="cell-border-left">
       {{#if data2.comparison_sum}}
-        {{numeral-format (sub data.comparison_sum data2.comparison_sum) '+0,0'}}
+        {{numeral-format (sub data.comparison_sum data2.comparison_sum) '0,0'}}
       {{else if (eq data2.comparison_sum 0)}}
-        {{numeral-format (sub data.comparison_sum data2.comparison_sum) '+0,0'}}
+        {{numeral-format (sub data.comparison_sum data2.comparison_sum) '0,0'}}
       {{else}}
-      n/a
+        &nbsp;
       {{/if}}
     </td>
     {{#if reliability}}
     <td>
       {{#if data2.comparison_sum}}
-        {{numeral-format (sqrt (add (pow (div data2.comparison_m 1.645) 2) (pow (div data.comparison_m 1.645) 2))) '+0,0'}}
+        {{numeral-format (sqrt (add (pow (div data2.comparison_m 1.645) 2) (pow (div data.comparison_m 1.645) 2))) '0,0'}}
       {{else if (eq data2.comparison_sum 0)}}
-        {{numeral-format (sqrt (add (pow (div data2.comparison_m 1.645) 2) (pow (div data.comparison_m 1.645) 2))) '+0,0'}}
+        {{numeral-format (sqrt (add (pow (div data2.comparison_m 1.645) 2) (pow (div data.comparison_m 1.645) 2))) '0,0'}}
       {{else}}
-        n/a
+        &nbsp;
       {{/if}}
     </td>
     {{/if}}
     <td>
-      {{#if data2.comparison_percent}}
-        {{numeral-format (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum) '+0.0%'}}
-      {{else if (eq data2.comparison_percent 0)}}
-        {{numeral-format (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum) '+0.0%'}}
+      {{#if data2.comparison_sum}}
+        {{#if data2.comparison_percent}}
+          {{numeral-format (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum) '0.0%'}}
+        {{else if (eq data2.comparison_percent 0)}}
+          {{numeral-format (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum) '0.0%'}}
+        {{else}}
+          &nbsp;
+        {{/if}}
       {{else}}
-      n/a
+        &nbsp;
       {{/if}}
     </td>
     {{#if reliability}}
       <td>
       {{#if data2.sum}}
-          {{numeral-format comparisonLongitudinalPercentMOE '+0.0%'}}
-        {{else if (eq data2.sum 0)}}
-          {{numeral-format comparisonLongitudinalPercentMOE '+0.0%'}}
+          {{numeral-format comparisonLongitudinalPercentMOE '0.0%'}}
         {{else}}
-          n/a
+          &nbsp;
         {{/if}}
       </td>
       {{/if}}
       <td class="cell-border-left">
         {{#if data2.sum}}
-          {{numeral-format (sub (sub data.sum data2.sum) (sub data.comparison_sum data2.comparison_sum)) '+0,0'}}
-        {{else if (eq data2.sum 0)}}
-          {{numeral-format (sub (sub data.sum data2.sum) (sub data.comparison_sum data2.comparison_sum)) '+0,0'}}
+          {{numeral-format (sub (sub data.sum data2.sum) (sub data.comparison_sum data2.comparison_sum)) '0,0'}}
         {{else}}
-          n/a
+          &nbsp;
         {{/if}}
       </td>
       {{#if reliability}}
         <td>
         {{#if data2.sum}}
-          {{numeral-format differenceMOE '+0,0'}}
-        {{else if (eq data2.sum 0)}}
-          {{numeral-format differenceMOE '+0,0'}}
+          {{numeral-format differenceMOE '0,0'}}
         {{else}}
-          n/a
+          &nbsp;
         {{/if}}
         </td>
       {{/if}}
       <td>
-        {{#if data2.percent}}
-          {{numeral-format (mult (sub (div (sub data.sum data2.sum) data2.sum) (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum)) 100) '+0.0'}}
-        {{else if (eq data2.percent 0)}}
-          {{numeral-format (mult (sub (div (sub data.sum data2.sum) data2.sum) (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum)) 100) '+0.0'}}
+        {{#if data2.sum}}
+          {{#if data2.percent}}
+            {{numeral-format (mult (sub (div (sub data.sum data2.sum) data2.sum) (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum)) 100) '0.0'}}
+          {{else if (eq data2.percent 0)}}
+            {{numeral-format (mult (sub (div (sub data.sum data2.sum) data2.sum) (div (sub data.comparison_sum data2.comparison_sum) data2.comparison_sum)) 100) '0.0'}}
+          {{else}}
+             &nbsp;
+          {{/if}}
         {{else}}
-          n/a
+          &nbsp;
         {{/if}}
       </td>
       {{#if reliability}}
       <td>
         {{#if data2.sum}}
-          {{numeral-format differencePercentMOE '+0.0%'}}
-        {{else if (eq data2.sum 0)}}
-          {{numeral-format differencePercentMOE '+0.0%'}}
+          {{numeral-format differencePercentMOE '0.0%'}}
         {{else}}
-          n/a
+          &nbsp;
         {{/if}}
       </td>
       {{/if}}

--- a/app/templates/components/acs-table.hbs
+++ b/app/templates/components/acs-table.hbs
@@ -43,8 +43,10 @@
       {{ else }} {{! change over time header}}
         <tr>
           <th rowspan="3">&nbsp;</th>
-          <th colspan="2" rowspan="2" class="text-center cell-border-bottom">2006-2010</th>
-          <th colspan="2" rowspan="2" class="text-center cell-border-bottom">2011-2015</th>
+          {{#unless comparison}}
+            <th colspan="2" rowspan="2" class="text-center cell-border-bottom">2006-2010</th>
+            <th colspan="2" rowspan="2" class="text-center cell-border-bottom">2011-2015</th>
+          {{/unless}}
           {{#if comparison}}
             {{#if reliability}}
               <th colspan="12" class="text-center cell-border-bottom">Change, 2006-2010 to 2011-2015</th>
@@ -67,10 +69,12 @@
           {{/if}}
         </tr>
         <tr>
-          <th>Number</th>
-          <th>Percent</th>
-          <th>Number</th>
-          <th>Percent</th>
+          {{#unless comparison}}
+            <th>Number</th>
+            <th>Percent</th>
+            <th>Number</th>
+            <th>Percent</th>
+          {{/unless}}
           <th>Estimate</th>
           {{#if reliability}}
             <th>MOE</th>
@@ -102,7 +106,7 @@
       {{/if}}
     </thead>
     <tbody>
-      {{#each config as |row|}} 
+      {{#each config as |row|}}
         {{#if hasBlock}}
           {{yield}}
         {{else}}


### PR DESCRIPTION
This PR closed issue 122, 148, 149, 155, 186
#122 - associated data columns appears blank for estimates of 0
#148 - Remove "+" signs
#149 - Remove columns from change over time profiles
#155 - Data not available or null appears as blank
#186 -  2011-2015 data appears blank in change over time when 2006-2010 data is not available
#261 - User should not see percent change over time, when earlier time (Census 2000 or ACS 2006-2010) is blank or zero

Closes #122, closes #148, closes #149, closes #155, closes #186