### PR TITLE
Scroll header-table programmatically

### DIFF
--- a/app/components/acs-table.js
+++ b/app/components/acs-table.js
@@ -43,9 +43,6 @@ export default Ember.Component.extend({
       const tableOffset = $(this).find('.data-table').offset();
       const offset = tableOffset.left - thisOffset.left;
       $(this).parents('.acs-table').find('.header-table').css({ marginLeft: offset });
-
-      // const offset = $(this).find('.data-table').offset();
-      // $(this).find('.sticky-element--sticky table').offset({ left: offset.left });
     });
 
     this.get('windowResize').on('didResize', () => {

--- a/app/components/acs-table.js
+++ b/app/components/acs-table.js
@@ -6,6 +6,7 @@ export default Ember.Component.extend({
   mode: 'current',
   reliability: false,
   comparison: true,
+  classNames: 'acs-table',
 
   windowResize: service(),
 
@@ -38,8 +39,13 @@ export default Ember.Component.extend({
 
   didInsertElement() {
     this.$('.table-scroll').on('scroll', function() {
-      const offset = $(this).find('.data-table').offset();
-      $(this).find('.sticky-element--sticky table').offset({ left: offset.left });
+      const thisOffset = $(this).offset();
+      const tableOffset = $(this).find('.data-table').offset();
+      const offset = tableOffset.left - thisOffset.left;
+      $(this).parents('.acs-table').find('.header-table').css({ marginLeft: offset });
+
+      // const offset = $(this).find('.data-table').offset();
+      // $(this).find('.sticky-element--sticky table').offset({ left: offset.left });
     });
 
     this.get('windowResize').on('didResize', () => {

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -447,6 +447,7 @@ button {
   position: relative;
   width: 100%;
   overflow: hidden;
+  margin-top: -1.5rem;
 
   table {
     margin-bottom: 0;
@@ -531,11 +532,9 @@ tbody td:first-child {
 }
 
 .table-copy-ui {
-  position: relative;
+  text-align: right;
 
   a {
-    position: absolute;
-    right: $global-margin;
     bottom: 0;
     margin: 0;
     border-bottom: 0;

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -443,8 +443,14 @@ button {
   margin: 0;
 }
 
-.table-scroll {
+.acs-table {
   position: relative;
+  width: 100%;
+  overflow: hidden;
+
+  table {
+    margin-bottom: 0;
+  }
 }
 
 thead {

--- a/app/templates/components/acs-table-header.hbs
+++ b/app/templates/components/acs-table-header.hbs
@@ -1,4 +1,4 @@
-<table>
+<table class="header-table">
   <thead>
     {{#if (eq mode 'current')}} {{! current header}}
       <tr>

--- a/app/templates/components/acs-table.hbs
+++ b/app/templates/components/acs-table.hbs
@@ -1,24 +1,24 @@
 <div class="table-copy-ui show-for-large">
   <a class="button tiny gray text-orange" {{action 'handleCopy'}}>{{fa-icon 'clipboard'}} Copy Table to Clipboard</a>
 </div>
-<div class="table-scroll">
 
-  {{#if media.isLarge}}
-    {{#sticky-element top=175 bottom=0}}
-      {{acs-table-header
-        reliability=reliability
-        comparison=comparison
-        mode=mode
-      }}
-    {{/sticky-element}}
-  {{else}}
+{{#if media.isLarge}}
+  {{#sticky-element top=175 bottom=0}}
     {{acs-table-header
       reliability=reliability
       comparison=comparison
       mode=mode
     }}
-  {{/if}}
+  {{/sticky-element}}
+{{else}}
+  {{acs-table-header
+    reliability=reliability
+    comparison=comparison
+    mode=mode
+  }}
+{{/if}}
 
+<div class="table-scroll">
   <table class="data-table">
     <tbody>
       {{#each config as |row|}}
@@ -38,5 +38,4 @@
       {{/each}}
     </tbody>
   </table>
-
 </div>

--- a/app/templates/components/acs-table.hbs
+++ b/app/templates/components/acs-table.hbs
@@ -11,11 +11,13 @@
     }}
   {{/sticky-element}}
 {{else}}
-  {{acs-table-header
-    reliability=reliability
-    comparison=comparison
-    mode=mode
-  }}
+  {{#sticky-element top=0 bottom=0}}
+    {{acs-table-header
+      reliability=reliability
+      comparison=comparison
+      mode=mode
+    }}
+  {{/sticky-element}}
 {{/if}}
 
 <div class="table-scroll">


### PR DESCRIPTION
This PR fixes the issue where scrolling a table horz before making its header sticky causes a misalignment of the columns. The solution is to remove the scrolling table headers from the `.table-scroll` div, listen for the scroll, and and programmatically set the `.header-table`'s left-margin. 