### PR TITLE
pass mode to decennial tables

### DIFF
--- a/app/templates/profile/census.hbs
+++ b/app/templates/profile/census.hbs
@@ -14,6 +14,7 @@
     {{#decennial-table category='decennial_sex_age' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=sexAge
         t1=table.categoryData.y2000
@@ -31,6 +32,7 @@
     {{#decennial-table category='decennial_mutually_exclusive_race' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=mutuallyExclRaceHisp
         t1=table.categoryData.y2000
@@ -48,6 +50,7 @@
     {{#decennial-table category='decennial_hispanic_subgroup' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=hispSubgroup
         t1=table.categoryData.y2000
@@ -65,6 +68,7 @@
     {{#decennial-table category='decennial_asian_subgroup' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=asianSubgroup
         t1=table.categoryData.y2000
@@ -82,6 +86,7 @@
     {{#decennial-table category='decennial_relationship_head_householder' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=headHousehold
         t1=table.categoryData.y2000
@@ -99,6 +104,7 @@
     {{#decennial-table category='decennial_household_type' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=householdType
         t1=table.categoryData.y2000
@@ -116,6 +122,7 @@
     {{#decennial-table category='decennial_housing_occupancy' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=housingOccupancy
         t1=table.categoryData.y2000
@@ -133,6 +140,7 @@
     {{#decennial-table category='decennial_housing_tenure' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=housingTenure
         t1=table.categoryData.y2000
@@ -150,6 +158,7 @@
     {{#decennial-table category='decennial_tenure_by_age' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=tenureAgeHouseholder
         t1=table.categoryData.y2000
@@ -167,6 +176,7 @@
     {{#decennial-table category='decennial_household_size' as |table|}}
       {{acs-table
         reliability=false
+        mode=profile.mode
         comparison=true
         config=householdSize
         t1=table.categoryData.y2000


### PR DESCRIPTION
The tables in the Census profile were not being passed the `mode` var, so nothing happened when you switched modes. Closes #272.
