### PR TITLE
add gray out rules for acs tables

### DIFF
--- a/app/templates/components/acs-table-row.hbs
+++ b/app/templates/components/acs-table-row.hbs
@@ -26,16 +26,17 @@
 
   {{else}}
     <td>{{rowconfig.title}}</td>
-    <td class="cell-border-left">{{numeral-format data.sum}}</td>
+
+    <td class="cell-border-left {{if (eq data.sum 0) 'medium-gray'}} {{if (gte data.cv 20) 'medium-gray'}}">{{numeral-format data.sum}}</td>
     {{#if reliability}}
-      <td>
+      <td class="{{if (gte data.cv 20) 'medium-gray'}}">
         {{#if data.sum}}
           {{numeral-format data.m}}
         {{else if (eq data.sum 0)}}
           &nbsp;
         {{/if}}
       </td>
-      <td>
+      <td class="{{if (gte data.cv 20) 'medium-gray'}}">
         {{#if data.sum}}
           {{numeral-format data.cv '0.0'}}
         {{else if (eq data.sum 0)}}
@@ -43,7 +44,7 @@
         {{/if}}
       </td>
     {{/if}}
-    <td>
+    <td class="{{if (gte data.cv 20) 'medium-gray'}}">
       {{#if data.sum}}
         {{numeral-format data.percent '0.0%'}}
       {{else if (eq data.sum 0)}}
@@ -51,7 +52,7 @@
       {{/if}}
     </td>
     {{#if reliability}}
-        <td>
+        <td class="{{if (gte data.cv 20) 'medium-gray'}}">
           {{#if data.sum}}
             {{numeral-format data.percent_m '0.0%'}}
           {{else if (eq data.sum 0)}}
@@ -60,16 +61,16 @@
         </td>
     {{/if}}
     {{#if comparison}}
-      <td class="cell-border-left">{{numeral-format data.comparison_sum}}</td>
+      <td class="cell-border-left {{if (eq data.comparison_sum 0) 'medium-gray'}} {{if (gte data.comparison_cv 20) 'medium-gray'}}">{{numeral-format data.comparison_sum}}</td>
       {{#if reliability}}
-        <td>
+        <td class="{{if (gte data.comparison_cv 20) 'medium-gray'}}">
           {{#if data.comparison_sum}}
             {{numeral-format data.comparison_m}}
           {{else if (eq data.comparison_sum 0)}}
             &nbsp;
           {{/if}}
         </td>
-        <td>
+        <td class="{{if (gte data.comparison_cv 20) 'medium-gray'}}">
           {{#if data.comparison_sum}}
             {{numeral-format data.comparison_cv '0.0'}}
           {{else if (eq data.comparison_sum 0)}}
@@ -77,7 +78,7 @@
           {{/if}}
         </td>
       {{/if}}
-      <td>
+      <td class="{{if (gte data.comparison_cv 20) 'medium-gray'}}">
         {{#if data.comparison_sum}}
           {{numeral-format data.comparison_percent '0.0%'}}
         {{else if (eq data.comparison_sum 0)}}
@@ -85,7 +86,7 @@
         {{/if}}
       </td>
       {{#if reliability}}
-          <td>
+          <td class="{{if (gte data.comparison_cv 20) 'medium-gray'}}">
             {{#if data.comparison_sum}}
               {{numeral-format data.comparison_percent_m '0.0%'}}
             {{else if (eq data.comparison_sum 0)}}


### PR DESCRIPTION
This PR adds logic to `acs-table-row` that checks for:

- estimates of 0 and grays out their associated columns
- CVs >= 20 and grays out their associated columns

Closes #29, some lingering issues from #29 are now in #157