### PR TITLE
Profile padding

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -229,16 +229,8 @@ body {
   }
 }
 
-.profile-content > .cell,
-.profile-sidebar {
-  padding: 0 rem-calc(20);
-}
-
-.profile-content > .cell {
-
-  @include breakpoint(large) {
-    padding-left: 0;
-  }
+#profile-content {
+  padding-bottom: 4rem;
 }
 
 // HACK: dot and pulse misalign without this.


### PR DESCRIPTION
This PR adds bottom padding to the profile. Its last table was flush against the bottom of the window, so you couldn't tell that you'd reached the end of the page. 

I've also nixed some old styles for the profile layout that we're no longer using. 