### PR TITLE
nix compare UI in change mode

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -248,6 +248,9 @@ button {
 }
 
 .profile-header {
+  @include breakpoint(large) {
+    min-height: rem-calc(230);
+  }
 
   h1 {
     margin-bottom: 0.25rem;

--- a/app/templates/components/profile-header.hbs
+++ b/app/templates/components/profile-header.hbs
@@ -55,6 +55,7 @@
         </ul>
       </div>
 
+      {{#if (eq mode 'current')}}
       <div class="profile-comparison-controls grid-x align-middle">
         <div class="cell shrink">
           <a {{action (mut profile.comparison) (not profile.comparison)}}>
@@ -70,6 +71,7 @@
           {{comparison-area-selector comparisonArea=profile.comparator}}
         </div>
       </div>
+      {{/if}}
 
       {{#unless (eq profile.tab 'profile.census') }}
       <div class="profile-reliability-controls">


### PR DESCRIPTION
This PR wraps the "compare to" UI in a conditional to only show for `mode: current`. 

Closes #310
