### PR TITLE
compare UI always on

### DIFF
--- a/app/templates/components/profile-header.hbs
+++ b/app/templates/components/profile-header.hbs
@@ -58,14 +58,7 @@
       {{#if (eq mode 'current')}}
       <div class="profile-comparison-controls grid-x align-middle">
         <div class="cell shrink">
-          <a {{action (mut profile.comparison) (not profile.comparison)}}>
-            {{#if profile.comparison}}
-              <span>{{fa-icon 'check-square-o' class="fa-fw"}}</span>
-            {{else}}
-              <span>{{fa-icon 'square-o' class="fa-fw"}}</span>
-            {{/if}}
-            Compare to &nbsp;
-          </a>
+          <strong>Compare&nbsp;to:&nbsp;&nbsp;</strong>
         </div>
         <div class="cell auto">
           {{comparison-area-selector comparisonArea=profile.comparator}}


### PR DESCRIPTION
This PR removes the compare UI's checkbox in the profile header so that you cannot turn off the comparison. 

Closes #311 
