### PR TITLE
fix CSS regression from data-table refactor

### DIFF
--- a/app/components/data-table.js
+++ b/app/components/data-table.js
@@ -33,7 +33,7 @@ export default Ember.Component.extend({
 
   actions: {
     handleCopy() {
-      const [el] = this.get('element').getElementsByClassName('table-scroll');
+      const [el] = this.get('element').getElementsByClassName('wrapper-for-copy');
       const body = document.body;
       let range;
       let sel;

--- a/app/components/data-table.js
+++ b/app/components/data-table.js
@@ -61,7 +61,7 @@ export default Ember.Component.extend({
   didInsertElement() {
     this.$('.table-scroll').on('scroll', function() {
       const thisOffset = $(this).offset();
-      const tableOffset = $(this).find('.data-table').offset();
+      const tableOffset = $(this).find('.body-table').offset();
       const offset = tableOffset.left - thisOffset.left;
       $(this).parents('.data-table').find('.header-table').css({ marginLeft: offset });
     });

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -265,5 +265,4 @@ body {
 
 .sticky-element--sticky {
   overflow: hidden;
-  z-index: 2;
 }

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -265,4 +265,5 @@ body {
 
 .sticky-element--sticky {
   overflow: hidden;
+  z-index: 2;
 }

--- a/app/table-config/social/household-type.js
+++ b/app/table-config/social/household-type.js
@@ -79,7 +79,7 @@ export default [
     special: true,
     aggregator: calculator,
     procedure: ['hhpop', 'divide', 'hh'],
-    decimal: 2,
+    decimal: 1,
   },
   {
     title: 'Average family size',
@@ -87,7 +87,7 @@ export default [
     special: true,
     aggregator: calculator,
     procedure: ['popinfms', 'division', 'fam'],
-    decimal: 2,
+    decimal: 1,
   },
   {
     divider: true,

--- a/app/templates/components/data-table.hbs
+++ b/app/templates/components/data-table.hbs
@@ -19,7 +19,7 @@
 {{/sticky-element}}
 
 <div class="table-scroll">
-  <table class="data-table">
+  <table class="body-table">
     <tbody>
       {{#each config as |row|}}
         {{#if hasBlock}}

--- a/app/templates/components/data-table.hbs
+++ b/app/templates/components/data-table.hbs
@@ -1,75 +1,75 @@
 <div class="table-copy-ui show-for-large">
   <a class="button tiny gray text-orange" {{action 'handleCopy'}}>{{fa-icon 'clipboard'}} Copy Table to Clipboard</a>
 </div>
-{{log mode}}
-{{#sticky-element top=stickyTop bottom=0}}
-  {{#if (eq mode 'current')}}
-    {{data-table-header-current
-      reliability=reliability
-      comparison=comparison
-      mode=mode
-    }}
-  {{else}}
-    {{data-table-header-change
-      reliability=reliability
-      comparison=comparison
-      mode=mode
-    }}
-  {{/if}}
-{{/sticky-element}}
 
-<div class="table-scroll">
-  <table class="body-table">
-    <tbody>
-      {{#each config as |row|}}
-        {{#if hasBlock}}
-          {{yield}}
-        {{else}}
-          {{#if (eq mode 'current')}}
-            {{data-table-row-current
-              mode=mode
-              reliability=reliability
-              comparison=comparison
-              rowconfig=row
-              options=profile
-              data=
-                (unless
-                  row.special
-                  (get this.t1 row.data)
-                  (aggregate-special-variable rowConfig=row data=t1)
-                )
-              data2=
-                (unless
-                  row.special
-                  (get this.t2 row.data)
-                  (aggregate-special-variable rowConfig=row data=t2)
-                )
-            }}
+<div class="wrapper-for-copy">
+  {{#sticky-element top=stickyTop bottom=0}}
+    {{#if (eq mode 'current')}}
+      {{data-table-header-current
+        reliability=reliability
+        comparison=comparison
+        mode=mode
+      }}
+    {{else}}
+      {{data-table-header-change
+        reliability=reliability
+        comparison=comparison
+        mode=mode
+      }}
+    {{/if}}
+  {{/sticky-element}}
+
+  <div class="table-scroll">
+    <table class="body-table">
+      <tbody>
+        {{#each config as |row|}}
+          {{#if hasBlock}}
+            {{yield}}
           {{else}}
-            {{data-table-row-change
-              mode=mode
-              reliability=reliability
-              comparison=comparison
-              rowconfig=row
-              options=profile
-              data=
-                (unless
-                  row.special
-                  (get this.t1 row.data)
-                  (aggregate-special-variable rowConfig=row data=t1)
-                )
-              data2=
-                (unless
-                  row.special
-                  (get this.t2 row.data)
-                  (aggregate-special-variable rowConfig=row data=t2)
-                )
-            }}
+            {{#if (eq mode 'current')}}
+              {{data-table-row-current
+                mode=mode
+                reliability=reliability
+                comparison=comparison
+                rowconfig=row
+                options=profile
+                data=
+                  (unless
+                    row.special
+                    (get this.t1 row.data)
+                    (aggregate-special-variable rowConfig=row data=t1)
+                  )
+                data2=
+                  (unless
+                    row.special
+                    (get this.t2 row.data)
+                    (aggregate-special-variable rowConfig=row data=t2)
+                  )
+              }}
+            {{else}}
+              {{data-table-row-change
+                mode=mode
+                reliability=reliability
+                comparison=comparison
+                rowconfig=row
+                options=profile
+                data=
+                  (unless
+                    row.special
+                    (get this.t1 row.data)
+                    (aggregate-special-variable rowConfig=row data=t1)
+                  )
+                data2=
+                  (unless
+                    row.special
+                    (get this.t2 row.data)
+                    (aggregate-special-variable rowConfig=row data=t2)
+                  )
+              }}
+            {{/if}}
           {{/if}}
-
-
-        {{/if}}
-      {{/each}}
-    </tbody>
-  </table>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
 </div>


### PR DESCRIPTION
This PR fixes a CSS regression that happened when `{{acs-table}}` was refactored and named `.data-table` (a class which already existed). I've changed what was previously `.acs-table` to `.body-table`, which is a better name since it works with the `.header-table` is used for sticky headers.