### PR TITLE
365 geography names

### DIFF
--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -21,7 +21,8 @@ export default Ember.Route.extend({
 
     return fetch(SELECTION_API_URL(id))
       .then(response => response.json())
-      .then(({ features }) => {
+      .then(({ features, type }) => {
+        selection.set('summaryLevel', type);
         selection.set('current', { type: 'FeatureCollection', features });
         return true;
       });

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -37,7 +37,36 @@ export default Ember.Service.extend({
 
   @computed('current')
   sortedLabels(currentSelected) {
-    return currentSelected.features.sort((a, b) => (a.properties.geolabel - b.properties.geolabel));
+    const { features } = currentSelected;
+
+    const bronx = features.filter(d => d.properties.borocode === '2');
+    const brooklyn = features.filter(d => d.properties.borocode === '3');
+    const manhattan = features.filter(d => d.properties.borocode === '1');
+    const queens = features.filter(d => d.properties.borocode === '4');
+    const statenisland = features.filter(d => d.properties.borocode === '5');
+
+    return [
+      {
+        label: 'Bronx',
+        features: bronx,
+      },
+      {
+        label: 'Brooklyn',
+        features: brooklyn,
+      },
+      {
+        label: 'Manhattan',
+        features: manhattan,
+      },
+      {
+        label: 'Queens',
+        features: queens,
+      },
+      {
+        label: 'Staten Island',
+        features: statenisland,
+      },
+    ];
   },
 
   pointLayer,

--- a/app/templates/components/profile-header.hbs
+++ b/app/templates/components/profile-header.hbs
@@ -47,13 +47,19 @@
           {{if (eq summaryLevel 'blocks') 'Census Block'~}}
           {{if (eq summaryLevel 'ntas') 'Neighborhood'~}}
           {{if (eq summaryLevel 'pumas') 'PUMA'~}}
-          {{unless (eq selectionCount 1) 's'}}:
-        </h3>
-        <ul class="profile-geographies-list comma-separated-list">
-          {{#each selection.sortedLabels as |feature|}}
-            <li>{{feature.properties.geolabel}}</li>
+          {{unless (eq selectionCount 1) 's'}}
+        </h3> |
+        <p class="profile-geographies-list comma-separated-list">
+          {{#each selection.sortedLabels as |boro|}}
+            {{#if boro.features.length}}
+              <strong>{{boro.label}}:</strong>
+            {{/if}}
+            {{#each boro.features as |feature|}}
+              {{feature.properties.geolabel}}
+              {{~unless (eq boro.features.lastObject.properties.geoid feature.properties.geoid) ','}}
+            {{/each}}
           {{/each}}
-        </ul>
+        </p>
       </div>
 
       {{#if (eq mode 'current')}}


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR updates the display labels for the list of selected geometries in the profile view

Changes Proposed:
- Depends on new values coming back as `geoid` from calls to factfinder-api `/selection` endpoint which are already deployed
- Also fixes a bug where everything was labeled as "Tracts" when loading a Profile directly (when not coming from the selection view)

Closes #365
