### PR TITLE
update decennial route to handle comparator param

### DIFF
--- a/app/adapters/row.js
+++ b/app/adapters/row.js
@@ -7,9 +7,8 @@ export default DS.JSONAPIAdapter.extend({
   query(store, modelType, query) {
     const { geoids, comparator, type, category } = query;
     let selectionSQL;
-
     if (type === 'decennial') {
-      selectionSQL = decennialProfile(geoids, category);
+      selectionSQL = decennialProfile(geoids, category, comparator);
     } else {
       selectionSQL = generateProfileSQL(geoids, comparator, type);
     }

--- a/app/routes/profile/census.js
+++ b/app/routes/profile/census.js
@@ -13,19 +13,19 @@ export default Ember.Route.extend({
     this.store.unloadAll();
   },
 
-  model() {
+  model(params, { queryParams: { comparator = '0' } }) {
     return {
-      sex_age: this.get('fetchCategory').perform('decennial_sex_age'),
-      population_density: this.get('fetchCategory').perform('decennial_population_density'),
-      mutually_exclusive_race: this.get('fetchCategory').perform('decennial_mutually_exclusive_race'),
-      hispanic_subgroup: this.get('fetchCategory').perform('decennial_hispanic_subgroup'),
-      asian_subgroup: this.get('fetchCategory').perform('decennial_asian_subgroup'),
-      relationship_head_householder: this.get('fetchCategory').perform('decennial_relationship_head_householder'),
-      household_type: this.get('fetchCategory').perform('decennial_household_type'),
-      housing_occupancy: this.get('fetchCategory').perform('decennial_housing_occupancy'),
-      housing_tenure: this.get('fetchCategory').perform('decennial_housing_tenure'),
-      tenure_by_age: this.get('fetchCategory').perform('decennial_tenure_by_age'),
-      household_size: this.get('fetchCategory').perform('decennial_household_size'),
+      sex_age: this.get('fetchCategory').perform('decennial_sex_age', comparator),
+      population_density: this.get('fetchCategory').perform('decennial_population_density', comparator),
+      mutually_exclusive_race: this.get('fetchCategory').perform('decennial_mutually_exclusive_race', comparator),
+      hispanic_subgroup: this.get('fetchCategory').perform('decennial_hispanic_subgroup', comparator),
+      asian_subgroup: this.get('fetchCategory').perform('decennial_asian_subgroup', comparator),
+      relationship_head_householder: this.get('fetchCategory').perform('decennial_relationship_head_householder', comparator),
+      household_type: this.get('fetchCategory').perform('decennial_household_type', comparator),
+      housing_occupancy: this.get('fetchCategory').perform('decennial_housing_occupancy', comparator),
+      housing_tenure: this.get('fetchCategory').perform('decennial_housing_tenure', comparator),
+      tenure_by_age: this.get('fetchCategory').perform('decennial_tenure_by_age', comparator),
+      household_size: this.get('fetchCategory').perform('decennial_household_size', comparator),
     };
   },
 
@@ -35,10 +35,10 @@ export default Ember.Route.extend({
     this.controllerFor('profile').set('tab', targetName);
   },
 
-  fetchCategory: task(function* (category) {
+  fetchCategory: task(function* (category, comparator) {
     const geoids = this.get('selection.current.features').mapBy('properties.geoid');
     const profileData = yield this.get('store')
-      .query('row', { geoids, type: 'decennial', category })
+      .query('row', { geoids, type: 'decennial', category, comparator })
       .then(rows => rows.toArray())
       .then(rows => nestProfile(rows, 'year', 'variable'));
 


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds some logic to the decennial route to make it listen for the comparator query param and adjust its queries accordingly.  

Adds comparison functionality to the decennial profile and closes #362
