### PR TITLE
71 geom switching

### DIFF
--- a/app/queries/summary-levels.js
+++ b/app/queries/summary-levels.js
@@ -34,4 +34,12 @@ export default {
     WHERE ntaname NOT ILIKE 'park-cemetery-etc%25'
       AND ntaname != 'Airport'
   `,
+
+  pumas: (webmercator = true) => `
+    SELECT
+      ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
+      puma AS geolabel,
+      puma AS geoid
+    FROM nyc_puma
+  `,
 };


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds the ability to transition between all geography types.  

Prior to this, we were handling things via the `explode()` method, which is only helpful if we have good lookup columns in the tables (which we do for blocks -> tracts and tracts -> ntas.  

This was the initial implementation, but it would  not work with PUMAs at all, and if you skipped a level (tried to go from blocks to ntas for example) it would not work.

For those to/from pairs that `explode()` can't handle, this PR adds `explodeGeo()` which uses `ST_Intersects()` and lets postgis figure out what should be included in an explosion/implosion.

Caveats: With large numbers of geometries, the response can take a while, and we should explore concurrency to delay updating the UI.  When going from blocks to ntas with hundreds of blocks selected, the response can take a few seconds, and the UI is an awkward state saying that XXXX Neighborhoods are selected until the response comes back.

TODO: Determine if `explodeGeo()` should just be used for _all_ transitions between geometry types.

Closes #71 

