### PR TITLE
Disallow single selection aggregation

### DIFF
--- a/app/mixins/downloadable.js
+++ b/app/mixins/downloadable.js
@@ -2,9 +2,11 @@ import Ember from 'ember';
 import nestProfile from '../utils/nest-profile';
 import delegateAggregator from '../utils/delegate-aggregator';
 
-const { get } = Ember;
+const { get, inject: { service } } = Ember;
 
 export default Ember.Mixin.create({
+  selection: service(),
+
   beforeModel(transition) {
     // unload to avoid the issue with duplicate ids.
     // there are duplicates because id is based arbitrarily on the array index.
@@ -18,8 +20,12 @@ export default Ember.Mixin.create({
     this._super(controller, model);
 
     const nestedModel = nestProfile(model, 'dataset', 'variable');
+    const { length: numberGeoids } = this.get('selection.current.features').mapBy('properties.geoid');
+
     model.forEach((row) => {
-      if (row.get('isSpecial')) {
+      // if the row is "special" and the number of geoids in the
+      // selection are greater than 1
+      if (row.get('isSpecial') && (numberGeoids > 1)) {
         const rowConfig = row.get('rowConfig');
         const latestYear = get(nestedModel, 'y2012_2016');
         row.setProperties(delegateAggregator(rowConfig, latestYear));


### PR DESCRIPTION
Adds conditional logic in route mixin to prevent app from applying aggregation logic

<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR prevents special aggregation methods when there is only one geography in the selection.

Changes Proposed:
- Add conditional to ACS-relevant route mixin `downloadable` (should be renamed at some point) to prevent application of special aggregation methods to rows when # of geogs = 1. 

Related to #274, which was closed, but this detail was missed. Was mentioned in some issues by @EricaMaurer.

Closes #214.