### PR TITLE
refactor percent MOE and Comparison percentMOE

### DIFF
--- a/app/queries/profile.js
+++ b/app/queries/profile.js
@@ -74,9 +74,17 @@ const generateProfileSQL = function(geoids, comparator, profile = 'demographic')
         regexp_replace(lower(VARIABLE), '[^A-Za-z0-9]', '_', 'g') AS VARIABLE,
         ENCODE(CONVERT_TO(VARIABLE || dataset, 'UTF-8'), 'base64') As id,
         ROUND((SUM / NULLIF(base_sum,0))::numeric, 4) as percent,
-        (1 / NULLIF(base_sum,0)) * SQRT(POWER(m, 2) %2D ABS(POWER(sum / NULLIF(base_sum,0), 2) * POWER(base_m, 2))) as percent_m,
+        CASE
+          WHEN (POWER(m, 2) %2D POWER(sum / NULLIF(base_sum,0), 2) * POWER(base_m, 2)) < 0
+            THEN (1 / NULLIF(base_sum,0)) * SQRT(POWER(m, 2) %2B POWER(sum / NULLIF(base_sum,0), 2) * POWER(base_m, 2))
+          ELSE (1 / NULLIF(base_sum,0)) * SQRT(POWER(m, 2) %2D POWER(sum / NULLIF(base_sum,0), 2) * POWER(base_m, 2))
+        END as percent_m,
         ROUND((comparison_sum / NULLIF(comparison_base_sum,0))::numeric, 4) as comparison_percent,
-        (1 / NULLIF(comparison_base_sum,0)) * SQRT(POWER(comparison_m, 2) %2D ABS(POWER(comparison_sum / NULLIF(comparison_base_sum,0), 2) * POWER(comparison_base_m, 2))) as comparison_percent_m
+        CASE
+          WHEN (POWER(comparison_m, 2) %2D POWER(comparison_sum / NULLIF(comparison_base_sum,0), 2) * POWER(comparison_base_m, 2)) < 0
+            THEN (1 / NULLIF(comparison_base_sum,0)) * SQRT(POWER(comparison_m, 2) %2B POWER(comparison_sum / NULLIF(comparison_base_sum,0), 2) * POWER(comparison_base_m, 2))
+          ELSE (1 / NULLIF(comparison_base_sum,0)) * SQRT(POWER(comparison_m, 2) %2D POWER(comparison_sum / NULLIF(comparison_base_sum,0), 2) * POWER(comparison_base_m, 2))
+        END as comparison_percent_m
       FROM (
         SELECT
           sum(e) filter (WHERE geoid IN (${ids})) AS sum,


### PR DESCRIPTION
This PR refactors the percent_m and comparison_percent_m fields in the ACS SQL query to better match what was provided by the customer and eliminate the square root of a negative error that was showing up after yesterday's fix

Related to #357
