### PR TITLE
clean up layout of advanced options

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -171,6 +171,7 @@ button {
   }
 }
 
+.primary-color { color: $primary-color; }
 .light-gray { color: $light-gray; }
 .medium-gray { color: $medium-gray; }
 .dark-gray { color: $dark-gray; }

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -162,7 +162,7 @@ body {
     z-index: 4;
     padding-bottom: 0;
     margin-top: rem-calc(92);
-    width: rem-calc(320);
+    width: rem-calc(330);
     box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
   }
 

--- a/app/styles/modules/_m-advanced-options.scss
+++ b/app/styles/modules/_m-advanced-options.scss
@@ -31,6 +31,10 @@ $advanced-options-hover-color: rgba($dark-gray,0.08);
 .layer-menu-item-content {
   padding: $advanced-options-margin;
   padding-top: 0;
+
+  &:empty {
+    display: none;
+  }
 }
 
 .radio-buttons-list {

--- a/app/templates/components/layer-menu-item.hbs
+++ b/app/templates/components/layer-menu-item.hbs
@@ -14,7 +14,7 @@
         {{#if titleTooltip}}
           {{info-tooltip
             tip=titleTooltip
-            classNames='layer-info'
+            classNames='layer-info primary-color'
             tooltipClass='tooltip--layer-info'
           }}
         {{/if}}
@@ -42,11 +42,11 @@
 
   {{#if visible}}
     <div class="layer-menu-item-content">
-      {{yield (hash
+      {{~yield (hash
         layer=layer
         updateSql=(action 'updateSql')
         updatePaintFor=(action 'updatePaintFor')
-        )}}
+        )~}}
     </div>
   {{/if}}
 

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -69,7 +69,8 @@
                     {{fa-icon 'circle-thin'}}
                   {{/if}}
                   {{log config}}
-                  {{config.label}} {{info-tooltip tip=config.tooltip}}
+                  {{config.label}}
+                  {{info-tooltip tip=config.tooltip classNames="primary-color"}}
                 </li>
               {{/each}}
             </ul>


### PR DESCRIPTION
This PR adjusts the width of the `.map-utility-box`, gives the tooltips a color to indicate interaction, and prevents toggling layer items without content from adding space below themselves by removing the whitespace and hiding when `:empty`. 