### PR TITLE
423 persist comparison area

### DIFF
--- a/app/adapters/row.js
+++ b/app/adapters/row.js
@@ -8,12 +8,12 @@ const { SupportServiceHost } = Environment;
 
 export default DS.JSONAPIAdapter.extend({
   query(store, modelType, query) {
-    const { selectionId, comparator, type } = query;
+    const { selectionId, comparator = 0, type } = query;
     let URL;
     if (type === 'decennial') {
-      URL = `${SupportServiceHost}/profile/${selectionId}/decennial`;
+      URL = `${SupportServiceHost}/profile/${selectionId}/decennial?compare=${comparator}`;
     } else {
-      URL = `${SupportServiceHost}/profile/${selectionId}/${type}`;
+      URL = `${SupportServiceHost}/profile/${selectionId}/${type}?compare=${comparator}`;
     }
 
     return fetch(URL)

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -26,7 +26,7 @@
               <li>{{#item.scroll-to href='#household-size'}}Household Size{{/item.scroll-to}}</li>
             {{/tab-dropdown}}
           {{else}}
-            {{#link-to 'profile.census' (query-params mode=mode)}}
+            {{#link-to 'profile.census' (query-params mode=mode comparator=comparator)}}
               Census
               {{tooltip-on-element delay=500 side="right" text='Basic population and housing characteristics from decennial census'}}
             {{/link-to}}
@@ -50,7 +50,7 @@
                 <li>{{#item.scroll-to href='#asian-subgroup'}}Asian Subgroup{{/item.scroll-to}}</li>
               {{/tab-dropdown}}
             {{else}}
-              {{#link-to 'profile.demographic' (query-params mode=mode)}}
+              {{#link-to 'profile.demographic' (query-params mode=mode comparator=comparator)}}
                 Demographic <small>(ACS)</small>
                 {{tooltip-on-element delay=500 side="right" text='Basic population characteristics from the American Community Survey'}}
               {{/link-to}}
@@ -77,7 +77,7 @@
                 <li>{{#item.scroll-to href='#ancestry'}}Ancestry{{/item.scroll-to}}</li>
               {{/tab-dropdown}}
             {{else}}
-              {{#link-to 'profile.social' (query-params mode=mode)}}
+              {{#link-to 'profile.social' (query-params mode=mode comparator=comparator)}}
                 Social <small>(ACS)</small>
                 {{tooltip-on-element delay=500 side="right" text='Social characteristics from the American Community Survey'}}
               {{/link-to}}
@@ -101,7 +101,7 @@
                 <li>{{#item.scroll-to href='#ratio-of-income-to-poverty-level'}}Ratio of Income to Poverty Level{{/item.scroll-to}}</li>
               {{/tab-dropdown}}
             {{else}}
-              {{#link-to 'profile.economic' (query-params mode=mode)}}
+              {{#link-to 'profile.economic' (query-params mode=mode comparator=comparator)}}
                 Economic <small>(ACS)</small>
                 {{tooltip-on-element delay=500 side="right" text='Economic characteristics from the American Community Survey'}}
               {{/link-to}}
@@ -128,7 +128,7 @@
                 <li>{{#item.scroll-to href='#gross-rent-as-a-percentage-of-household-income'}}Gross Rent as a Percentage of Household Income (GRAPI){{/item.scroll-to}}</li>
               {{/tab-dropdown}}
             {{else}}
-              {{#link-to 'profile.housing' (query-params mode=mode)}}
+              {{#link-to 'profile.housing' (query-params mode=mode comparator=comparator)}}
                 Housing <small>(ACS)</small>
                 {{tooltip-on-element delay=500 side="right" text='Housing characteristics from the American Community Survey'}}
               {{/link-to}}


### PR DESCRIPTION
This PR:

- updates the profile tabs so that the `comparator` query param is persisted (the selected comparison area will persist when switching tabs.

- adds `compare` query parameter to the `profile` API calls (restores comparison area functionality now that query logic has been moved to the backend)