### PR TITLE
ensure graying only occurs on acs profiles

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -543,6 +543,9 @@ tbody td:first-child {
   }
 }
 
+.shows-signficance .insignificant { color: $medium-gray; }
+
+
 //
 // Callouts
 // --------------------------------------------------

--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -30,39 +30,39 @@
   </td>
 
   {{!-- OLD --}}
-  <td class="cell-border-left {{if (eq data2.sum 0) 'medium-gray'}} {{if (gte data2.cv 20) 'medium-gray'}}">{{selectedEarlySum}}</td>{{!-- previous dataset sum--}}
+  <td class="cell-border-left {{if (eq data2.sum 0) 'insignificant'}} {{if (gte data2.cv 20) 'insignificant'}}">{{selectedEarlySum}}</td>{{!-- previous dataset sum--}}
   {{#if reliability}}
-    <td class="{{if (gte data2.cv 20) 'medium-gray'}}">{{selectedEarlySumM}}</td>
-    <td class="{{if (gte data2.cv 20) 'medium-gray'}}">{{selectedEarlySumCV}}</td>
+    <td class="{{if (gte data2.cv 20) 'insignificant'}}">{{selectedEarlySumM}}</td>
+    <td class="{{if (gte data2.cv 20) 'insignificant'}}">{{selectedEarlySumCV}}</td>
   {{/if}}
-  <td class="{{if (gte data2.cv 20) 'medium-gray'}}">{{selectedEarlyPercent}}</td>{{!-- previous dataset percent --}}
+  <td class="{{if (gte data2.cv 20) 'insignificant'}}">{{selectedEarlyPercent}}</td>{{!-- previous dataset percent --}}
   {{#if reliability}}
-    <td class="{{if (gte data2.cv 20) 'medium-gray'}}">{{data2.selectedPercentM}}</td>
+    <td class="{{if (gte data2.cv 20) 'insignificant'}}">{{data2.selectedPercentM}}</td>
   {{/if}}
 
   {{!-- CURRENT --}}
-  <td class="cell-border-left {{if (eq data.sum 0) 'medium-gray'}} {{if (gte data.cv 20) 'medium-gray'}}">{{selectedCurrentSum}}</td>{{!-- current dataset sum --}}
+  <td class="cell-border-left {{if (eq data.sum 0) 'insignificant'}} {{if (gte data.cv 20) 'insignificant'}}">{{selectedCurrentSum}}</td>{{!-- current dataset sum --}}
   {{#if reliability}}
-    <td class="{{if (gte data.cv 20) 'medium-gray'}}">{{selectedCurrentSumM}}</td>
-    <td class="{{if (gte data.cv 20) 'medium-gray'}}">{{selectedCurrentSumCV}}</td>
+    <td class="{{if (gte data.cv 20) 'insignificant'}}">{{selectedCurrentSumM}}</td>
+    <td class="{{if (gte data.cv 20) 'insignificant'}}">{{selectedCurrentSumCV}}</td>
   {{/if}}
-  <td class="{{if (gte data.cv 20) 'medium-gray'}}">{{selectedCurrentPercent}}</td>{{!-- current dataset percent --}}
+  <td class="{{if (gte data.cv 20) 'insignificant'}}">{{selectedCurrentPercent}}</td>{{!-- current dataset percent --}}
   {{#if reliability}}
-    <td class="{{if (gte data.cv 20) 'medium-gray'}}">{{data.selectedPercentM}}</td>
+    <td class="{{if (gte data.cv 20) 'insignificant'}}">{{data.selectedPercentM}}</td>
   {{/if}}
 
   {{!-- DIFFERENCE --}}
-  <td class="cell-border-left {{if changeInsignificant 'medium-gray'}}">{{change}}</td>{{!-- selected area sum change --}}
+  <td class="cell-border-left {{if changeInsignificant 'insignificant'}}">{{change}}</td>{{!-- selected area sum change --}}
   {{#if reliability}}
-    <td class="{{if changeInsignificant 'medium-gray'}}">{{changeMOE}}</td>{{!-- selected area sum change moe --}}
+    <td class="{{if changeInsignificant 'insignificant'}}">{{changeMOE}}</td>{{!-- selected area sum change moe --}}
   {{/if}}
-  <td class="{{if changePercentInsignificant 'medium-gray'}}">{{changePercent}}</td>{{!-- selected area percent change --}}
+  <td class="{{if changePercentInsignificant 'insignificant'}}">{{changePercent}}</td>{{!-- selected area percent change --}}
   {{#if reliability}}
-    <td class="{{if changePercentInsignificant 'medium-gray'}}">{{changePercentMOE}}</td>{{!-- selected area percent change moe --}}
+    <td class="{{if changePercentInsignificant 'insignificant'}}">{{changePercentMOE}}</td>{{!-- selected area percent change moe --}}
   {{/if}}
-  <td class="{{if changePercentagePointInsignificant 'medium-gray'}}">{{changePercentagePoint}}</td>
+  <td class="{{if changePercentagePointInsignificant 'insignificant'}}">{{changePercentagePoint}}</td>
   {{#if reliability}}
-    <td class="{{if changePercentagePointInsignificant 'medium-gray'}}">{{changePercentagePointMOE}}</td>
+    <td class="{{if changePercentagePointInsignificant 'insignificant'}}">{{changePercentagePointMOE}}</td>
   {{/if}}
 
 

--- a/app/templates/components/data-table-row-current.hbs
+++ b/app/templates/components/data-table-row-current.hbs
@@ -33,53 +33,53 @@
   </td>
 
   {{!-- SELECTED AREA --}}
-  <td class="cell-border-left {{if (eq data.sum 0) 'medium-gray'}} {{if (gte data.cv 20) 'medium-gray'}}">
+  <td class="cell-border-left {{if (eq data.sum 0) 'insignificant'}} {{if (gte data.cv 20) 'insignificant'}}">
     {{format-as data.sum rowconfig.decimal}}
   </td>
   {{#if reliability}}
-    <td class="{{if (gte data.cv 20) 'medium-gray'}}">
+    <td class="{{if (gte data.cv 20) 'insignificant'}}">
       {{format-as data.selectedSumMoE rowconfig.decimal}}
     </td>
-    <td class="{{if (gte data.cv 20) 'medium-gray'}}">
+    <td class="{{if (gte data.cv 20) 'insignificant'}}">
       {{data.selectedCV}}
     </td>
   {{/if}}
 
-  <td class="{{if (gte data.cv 20) 'medium-gray'}}">
+  <td class="{{if (gte data.cv 20) 'insignificant'}}">
     {{data.selectedPercent}}
   </td>
   {{#if reliability}}
-    <td class="{{if (gte data.cv 20) 'medium-gray'}}">
+    <td class="{{if (gte data.cv 20) 'insignificant'}}">
       {{data.selectedPercentM}}
     </td>
   {{/if}}
 
   {{!-- COMPARISON AREA --}}
-  <td class="cell-border-left {{if (eq data.comparison_sum 0) 'medium-gray'}} {{if (gte data.comparison_cv 20) 'medium-gray'}}">
+  <td class="cell-border-left {{if (eq data.comparison_sum 0) 'insignificant'}} {{if (gte data.comparison_cv 20) 'insignificant'}}">
     {{format-as data.comparison_sum rowconfig.decimal}}
   </td>
   {{#if reliability}}
-    <td class="{{if (gte data.comparison_cv 20) 'medium-gray'}}">
+    <td class="{{if (gte data.comparison_cv 20) 'insignificant'}}">
       {{format-as data.comparisonSumMoE rowconfig.decimal}}
     </td>
-    <td class="{{if (gte data.comparison_cv 20) 'medium-gray'}}">
+    <td class="{{if (gte data.comparison_cv 20) 'insignificant'}}">
       {{data.comparisonCV}}
     </td>
   {{/if}}
 
-  <td class="{{if (gte data.comparison_cv 20) 'medium-gray'}}">{{data.comparisonPercent}}</td>
+  <td class="{{if (gte data.comparison_cv 20) 'insignificant'}}">{{data.comparisonPercent}}</td>
   {{#if reliability}}
-    <td class="{{if (gte data.comparison_cv 20) 'medium-gray'}}">{{data.comparisonPercentM}}</td>
+    <td class="{{if (gte data.comparison_cv 20) 'insignificant'}}">{{data.comparisonPercentM}}</td>
   {{/if}}
 
   {{!-- DIFFERENCE --}}
-  <td class="cell-border-left {{unless data.significant 'medium-gray'}}">
+  <td class="cell-border-left {{unless data.significant 'insignificant'}}">
     {{format-as data.differenceSum rowconfig.decimal}}
   </td>
   {{#if reliability}}
     <td>{{data.differenceM}}</td>
   {{/if}}
-  <td class="{{unless data.percent_significant 'medium-gray'}}">
+  <td class="{{unless data.percent_significant 'insignificant'}}">
     {{data.differencePercent}}
   </td>
   {{#if reliability}}

--- a/app/templates/profile/demographic.hbs
+++ b/app/templates/profile/demographic.hbs
@@ -1,116 +1,118 @@
-{{profile-header
-  profile=profile
-  title="Demographic Profile"
-  mode=profile.mode
-  data=rawData
-}}
-<hr>
+<div class="shows-signficance">
+  {{profile-header
+    profile=profile
+    title="Demographic Profile"
+    mode=profile.mode
+    data=rawData
+  }}
+  <hr>
 
-<h3 id="sex-and-age" class="header-medium">Sex and Age</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=sexAndAge
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{#population-pyramid
-        title="Age/Sex Distribution"
-        data=agePopDist
+  <h3 id="sex-and-age" class="header-medium">Sex and Age</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=sexAndAge
+        model=model
       }}
-        <h4 class="no-margin grid-x grid-margin-x" style="font-size:0.75rem;">
-          <span class="cell small-6 text-right">
-            Male <br>{{numeral-format model.y2012_2016.male.percent '0.0%'}}&nbsp;<span class="text-weight-normal">(±{{numeral-format model.y2012_2016.male.percent_m '0.0%'}})</span>
-          </span>
-          <span class="cell small-6">
-            Female <br>{{numeral-format model.y2012_2016.fem.percent '0.0%'}}&nbsp;<span class="text-weight-normal">(±{{numeral-format model.y2012_2016.fem.percent_m '0.0%'}})</span>
-          </span>
-        </h4>
-      {{/population-pyramid}}
-    {{/if}}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{#population-pyramid
+          title="Age/Sex Distribution"
+          data=agePopDist
+        }}
+          <h4 class="no-margin grid-x grid-margin-x" style="font-size:0.75rem;">
+            <span class="cell small-6 text-right">
+              Male <br>{{numeral-format model.y2012_2016.male.percent '0.0%'}}&nbsp;<span class="text-weight-normal">(±{{numeral-format model.y2012_2016.male.percent_m '0.0%'}})</span>
+            </span>
+            <span class="cell small-6">
+              Female <br>{{numeral-format model.y2012_2016.fem.percent '0.0%'}}&nbsp;<span class="text-weight-normal">(±{{numeral-format model.y2012_2016.fem.percent_m '0.0%'}})</span>
+            </span>
+          </h4>
+        {{/population-pyramid}}
+      {{/if}}
+    </div>
   </div>
+
+  <hr>
+
+  <h3 id="mutually-exclusive-race-hispanic-origin" class="header-medium">Mutually Exclusive Race / Hispanic Origin</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=mutuallyExclusiveRaceHispanicOrigin
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Race/Hispanic Origin Groups"
+          config=raceGroupChartConfig
+          data=model.y2012_2016
+          height=176
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 id="hispanic-subgroup" class="header-medium">Hispanic Subgroup</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=hispanicSubgroup
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Hispanic Subgroups"
+          config=hispanicSubgroupChartConfig
+          data=model.y2012_2016
+          height=204
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 id="asian-subgroup" class="header-medium">Asian Subgroup</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=asianSubgroup
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Asian Subgroups"
+          config=asianSubgroupChartConfig
+          data=model.y2012_2016
+          height=150
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  {{profile-footer}}
+
+  {{outlet}}
 </div>
-
-<hr>
-
-<h3 id="mutually-exclusive-race-hispanic-origin" class="header-medium">Mutually Exclusive Race / Hispanic Origin</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=mutuallyExclusiveRaceHispanicOrigin
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Race/Hispanic Origin Groups"
-        config=raceGroupChartConfig
-        data=model.y2012_2016
-        height=176
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 id="hispanic-subgroup" class="header-medium">Hispanic Subgroup</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=hispanicSubgroup
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Hispanic Subgroups"
-        config=hispanicSubgroupChartConfig
-        data=model.y2012_2016
-        height=204
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 id="asian-subgroup" class="header-medium">Asian Subgroup</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=asianSubgroup
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Asian Subgroups"
-        config=asianSubgroupChartConfig
-        data=model.y2012_2016
-        height=150
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-{{profile-footer}}
-
-{{outlet}}

--- a/app/templates/profile/economic.hbs
+++ b/app/templates/profile/economic.hbs
@@ -1,232 +1,234 @@
-{{profile-header
-  profile=profile
-  title="Economic Profile"
-  data=rawData
-  mode=profile.mode
-}}
+<div class="shows-signficance">
+  {{profile-header
+    profile=profile
+    title="Economic Profile"
+    data=rawData
+    mode=profile.mode
+  }}
 
-<hr>
+  <hr>
 
-<h3 class="header-medium" id="employment-status">Employment Status</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=employmentStatus
-      model=model
-    }}
+  <h3 class="header-medium" id="employment-status">Employment Status</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=employmentStatus
+        model=model
+      }}
+    </div>
   </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="commute-to-work">Commute to Work</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=commuteToWork
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Workers by Means of Transportation to Work"
+          config=commuteToWorkChartConfig
+          data=model.y2012_2016
+          height=236
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="occupation">Occupation</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=occupation
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Workers by Occupation"
+          config=occupationChartConfig
+          data=model.y2012_2016
+          height=204
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="industry">Industry</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=industry
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="class-of-worker">Class of Worker</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=classOfWorker
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Workers by Class of Worker"
+          config=classOfWorkerChartConfig
+          data=model.y2012_2016
+          height=176
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="income-and-benefits">
+    Income and Benefits
+    {{info-tooltip tip="In 2016 inflation-adjusted dollars"}}
+  </h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=incomeAndBenefits
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Household Income"
+          config=incomeAndBenefitsChartConfig
+          data=model.y2012_2016
+          height=340
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="earnings">
+    Earnings
+    {{info-tooltip tip="In 2016 inflation-adjusted dollars"}}
+  </h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=earnings
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="health-insurance-coverage">Health Insurance Coverage</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=healthInsuranceCoverage
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="income-in-the-past-12-months-below-poverty-level">
+    Income in the Past 12 Months Below Poverty Level
+    {{info-tooltip tip="For alternative NYC poverty measure, please see website of the Mayor's Office for Economic Opportunity"}}
+  </h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=incomeInPast12MonthsIsBelowThePovertyLevel
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="ratio-of-income-to-poverty-level">
+    Ratio of Income to Poverty Level
+    {{info-tooltip tip="Ratio of income in the past 12 months to poverty level"}}
+  </h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=ratioOfIncomeToPovertyLevel
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Population by Ratio of Income to Poverty Level"
+          config=ratioOfIncomeToPovertyLevelChartConfig
+          data=model.y2012_2016
+          height=394
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  {{profile-footer}}
+
+  {{outlet}}
 </div>
-
-<hr>
-
-<h3 class="header-medium" id="commute-to-work">Commute to Work</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=commuteToWork
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Workers by Means of Transportation to Work"
-        config=commuteToWorkChartConfig
-        data=model.y2012_2016
-        height=236
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="occupation">Occupation</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=occupation
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Workers by Occupation"
-        config=occupationChartConfig
-        data=model.y2012_2016
-        height=204
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="industry">Industry</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=industry
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="class-of-worker">Class of Worker</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=classOfWorker
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Workers by Class of Worker"
-        config=classOfWorkerChartConfig
-        data=model.y2012_2016
-        height=176
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="income-and-benefits">
-  Income and Benefits
-  {{info-tooltip tip="In 2016 inflation-adjusted dollars"}}
-</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=incomeAndBenefits
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Household Income"
-        config=incomeAndBenefitsChartConfig
-        data=model.y2012_2016
-        height=340
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="earnings">
-  Earnings
-  {{info-tooltip tip="In 2016 inflation-adjusted dollars"}}
-</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=earnings
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="health-insurance-coverage">Health Insurance Coverage</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=healthInsuranceCoverage
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="income-in-the-past-12-months-below-poverty-level">
-  Income in the Past 12 Months Below Poverty Level
-  {{info-tooltip tip="For alternative NYC poverty measure, please see website of the Mayor's Office for Economic Opportunity"}}
-</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=incomeInPast12MonthsIsBelowThePovertyLevel
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="ratio-of-income-to-poverty-level">
-  Ratio of Income to Poverty Level
-  {{info-tooltip tip="Ratio of income in the past 12 months to poverty level"}}
-</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=ratioOfIncomeToPovertyLevel
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Population by Ratio of Income to Poverty Level"
-        config=ratioOfIncomeToPovertyLevelChartConfig
-        data=model.y2012_2016
-        height=394
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-{{profile-footer}}
-
-{{outlet}}

--- a/app/templates/profile/housing.hbs
+++ b/app/templates/profile/housing.hbs
@@ -1,275 +1,277 @@
-{{profile-header
-  profile=profile
-  title="Housing Profile"
-  mode=profile.mode
-  data=rawData
-}}
+<div class="shows-signficance">
+  {{profile-header
+    profile=profile
+    title="Housing Profile"
+    mode=profile.mode
+    data=rawData
+  }}
 
-<hr>
+  <hr>
 
-<h3 class="header-medium" id="housing-occupancy">Housing Occupancy</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=housingOccupancy
-      model=model
-    }}
+  <h3 class="header-medium" id="housing-occupancy">Housing Occupancy</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=housingOccupancy
+        model=model
+      }}
+    </div>
   </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="units-in-structure">Units in Structure</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=unitsInStructure
+        model=model
+      }}
+    </div>
+  </div>
+  <hr>
+
+  <h3 class="header-medium" id="year-structure-built">Year Structure Built</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=yearStructureBuilt
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="rooms">Rooms</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=rooms
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="housing-tenure">Housing Tenure</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=housingTenure
+        model=model
+        category='housing_tenure'
+        special_variables='housing__special_variable'
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Housing Tenure"
+          config=housingTenureChartConfig
+          data=model.y2012_2016
+          height=122
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="year-householder-moved-into-unit">Year Householder Moved Into Unit</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=yearHouseholderMovedIntoUnit
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="vehicles-available">Vehicles Available</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=vehiclesAvailable
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Households by Vehicles Available"
+          config=vehiclesAvailableChartConfig
+          data=model.y2012_2016
+          height=176
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="occupants-per-room">Occupants per Room</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=occupantsPerRoom
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="value">
+    Value
+    {{info-tooltip tip='In 2016 inflation-adjusted dollars'}}
+  </h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=value
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Owner-occupied Households by Housing Value"
+          config=valueChartConfig
+          data=model.y2012_2016
+          height=283
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="mortgage-status">Mortgage Status</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=mortgageStatus
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="selected-monthly-owner-costs-as-a-percentage-of-household-income">Selected Monthly Owner Costs as a Percentage of Household Income</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=selectedMonthlyOwnerCostsAsAPercentageOfHouseholdIncomeSmocapi
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="gross-rent">
+    Gross Rent
+    {{info-tooltip tip='In 2016 inflation-adjusted dollars'}}
+  </h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=grossRent
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Renter-occupied Households by Gross Rent"
+          config=grossRentChartConfig
+          data=model.y2012_2016
+          height=264
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="gross-rent-as-a-percentage-of-household-income">Gross Rent as a Percentage of Household Income (GRAPI)</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=grossRentAsAPercentageOfHouseholdIncomeGrapi
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Renter-occupied Households by Gross Rent as a Percentage of Household Income"
+          config=grossRentGrapiChartConfig
+          data=model.y2012_2016
+          height=235
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  {{profile-footer}}
+
+  {{outlet}}
 </div>
-
-<hr>
-
-<h3 class="header-medium" id="units-in-structure">Units in Structure</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=unitsInStructure
-      model=model
-    }}
-  </div>
-</div>
-<hr>
-
-<h3 class="header-medium" id="year-structure-built">Year Structure Built</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=yearStructureBuilt
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="rooms">Rooms</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=rooms
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="housing-tenure">Housing Tenure</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=housingTenure
-      model=model
-      category='housing_tenure'
-      special_variables='housing__special_variable'
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Housing Tenure"
-        config=housingTenureChartConfig
-        data=model.y2012_2016
-        height=122
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="year-householder-moved-into-unit">Year Householder Moved Into Unit</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=yearHouseholderMovedIntoUnit
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="vehicles-available">Vehicles Available</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=vehiclesAvailable
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Households by Vehicles Available"
-        config=vehiclesAvailableChartConfig
-        data=model.y2012_2016
-        height=176
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="occupants-per-room">Occupants per Room</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=occupantsPerRoom
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="value">
-  Value
-  {{info-tooltip tip='In 2016 inflation-adjusted dollars'}}
-</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=value
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Owner-occupied Households by Housing Value"
-        config=valueChartConfig
-        data=model.y2012_2016
-        height=283
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="mortgage-status">Mortgage Status</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=mortgageStatus
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="selected-monthly-owner-costs-as-a-percentage-of-household-income">Selected Monthly Owner Costs as a Percentage of Household Income</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=selectedMonthlyOwnerCostsAsAPercentageOfHouseholdIncomeSmocapi
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="gross-rent">
-  Gross Rent
-  {{info-tooltip tip='In 2016 inflation-adjusted dollars'}}
-</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=grossRent
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Renter-occupied Households by Gross Rent"
-        config=grossRentChartConfig
-        data=model.y2012_2016
-        height=264
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="gross-rent-as-a-percentage-of-household-income">Gross Rent as a Percentage of Household Income (GRAPI)</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=grossRentAsAPercentageOfHouseholdIncomeGrapi
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Renter-occupied Households by Gross Rent as a Percentage of Household Income"
-        config=grossRentGrapiChartConfig
-        data=model.y2012_2016
-        height=235
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-{{profile-footer}}
-
-{{outlet}}

--- a/app/templates/profile/social.hbs
+++ b/app/templates/profile/social.hbs
@@ -1,290 +1,292 @@
-{{profile-header
-  profile=profile
-  title="Social Profile"
-  mode=profile.mode
-  data=rawData
-}}
+<div class="shows-signficance">
+  {{profile-header
+    profile=profile
+    title="Social Profile"
+    mode=profile.mode
+    data=rawData
+  }}
 
-<hr>
+  <hr>
 
-<h3 class="header-medium" id="household-type">Household Type</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=householdType
-      model=model
-    }}
+  <h3 class="header-medium" id="household-type">Household Type</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=householdType
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Household Types"
+          config=householdTypeChartConfig
+          data=model.y2012_2016
+          height=176
+          xMax=1}}
+      {{/if}}
+    </div>
   </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Household Types"
-        config=householdTypeChartConfig
-        data=model.y2012_2016
-        height=176
-        xMax=1}}
-    {{/if}}
+
+  <hr>
+
+  <h3 class="header-medium" id="relationship-to-head-of-household">Relationship To Head Of Household (Householder)</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=relationshipToHeadOfHouseholdHouseholder
+        model=model
+      }}
+    </div>
   </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="grandparents">Marital Status</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=maritalStatus
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="grandparents">Grandparents</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=grandparents
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="school-enrollment">School Enrollment</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=schoolEnrollment
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Population 3 and Over by School Enrollment"
+          config=schoolEnrollmentChartConfig
+          data=model.y2012_2016
+          height=204
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="educational-attainment">Educational Attainment (Highest Grade Completed)</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=educationalAttainmentHighestGradeCompleted
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Population 25 and Over by Educational Attainment"
+          config=educationalAttainmentChartConfig
+          data=model.y2012_2016
+          height=150
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="veteran-status">Veteran Status</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=veteranStatus
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="disability-status-of-the-civilian-noninstitutionalized-population">Disability Status Of The Civilian Noninstitutionalized Population</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=disabilityStatusOfTheCivilianNoninstitutionalizedPopulation
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="residence-1-year-ago">Residence 1 Year Ago</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=residence1YearAgo
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Population who Lived in a Different House 1 Year Ago"
+          config=residence1YearAgoChartConfig
+          data=model.y2012_2016
+          height=176
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="place-of-birth">Place Of Birth</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=placeOfBirth
+        model=model
+      }}
+    </div>
+    <div class="cell large-4">
+      {{#if (eq profile.mode 'current')}}
+        {{acs-bar
+          title="Percent Distribution of Total Population by Place of Birth"
+          config=placeOfBirthChartConfig
+          data=model.y2012_2016
+          height=150
+          xMax=1}}
+        {{acs-bar
+          title="Percent Distribution of Foreign-Born by World Region of Birth"
+          config=foreignBornChartConfig
+          data=model.y2012_2016
+          height=176
+          xMax=1}}
+      {{/if}}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="us-citizenship-status">U.S. Citizenship Status</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=uSCitizenshipStatus
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="year-of-entry">Year Of Entry</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=yearOfEntry
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="language-spoken-at-home">Language Spoken At Home <small class="dark-gray">| data are from 2011-2015 ACS <sup>{{info-tooltip iconName='info-circle' tip='Detailed language data are not available from the 2012-2016 ACS Summary File'}}</sup></small></h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=languageSpokenAtHome
+        model=model
+      }}
+    </div>
+  </div>
+
+  <hr>
+
+  <h3 class="header-medium" id="ancestry">Ancestry</h3>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      {{data-table
+        options=profile
+        mode=profile.mode
+        reliability=profile.reliability
+        comparison=profile.comparison
+        config=ancestry
+        model=model
+      }}
+    </div>
+  </div>
+
+  {{profile-footer}}
+
+  {{outlet}}
 </div>
-
-<hr>
-
-<h3 class="header-medium" id="relationship-to-head-of-household">Relationship To Head Of Household (Householder)</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=relationshipToHeadOfHouseholdHouseholder
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="grandparents">Marital Status</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=maritalStatus
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="grandparents">Grandparents</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=grandparents
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="school-enrollment">School Enrollment</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=schoolEnrollment
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Population 3 and Over by School Enrollment"
-        config=schoolEnrollmentChartConfig
-        data=model.y2012_2016
-        height=204
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="educational-attainment">Educational Attainment (Highest Grade Completed)</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=educationalAttainmentHighestGradeCompleted
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Population 25 and Over by Educational Attainment"
-        config=educationalAttainmentChartConfig
-        data=model.y2012_2016
-        height=150
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="veteran-status">Veteran Status</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=veteranStatus
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="disability-status-of-the-civilian-noninstitutionalized-population">Disability Status Of The Civilian Noninstitutionalized Population</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=disabilityStatusOfTheCivilianNoninstitutionalizedPopulation
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="residence-1-year-ago">Residence 1 Year Ago</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=residence1YearAgo
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Population who Lived in a Different House 1 Year Ago"
-        config=residence1YearAgoChartConfig
-        data=model.y2012_2016
-        height=176
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="place-of-birth">Place Of Birth</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=placeOfBirth
-      model=model
-    }}
-  </div>
-  <div class="cell large-4">
-    {{#if (eq profile.mode 'current')}}
-      {{acs-bar
-        title="Percent Distribution of Total Population by Place of Birth"
-        config=placeOfBirthChartConfig
-        data=model.y2012_2016
-        height=150
-        xMax=1}}
-      {{acs-bar
-        title="Percent Distribution of Foreign-Born by World Region of Birth"
-        config=foreignBornChartConfig
-        data=model.y2012_2016
-        height=176
-        xMax=1}}
-    {{/if}}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="us-citizenship-status">U.S. Citizenship Status</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=uSCitizenshipStatus
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="year-of-entry">Year Of Entry</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=yearOfEntry
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="language-spoken-at-home">Language Spoken At Home <small class="dark-gray">| data are from 2011-2015 ACS <sup>{{info-tooltip iconName='info-circle' tip='Detailed language data are not available from the 2012-2016 ACS Summary File'}}</sup></small></h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=languageSpokenAtHome
-      model=model
-    }}
-  </div>
-</div>
-
-<hr>
-
-<h3 class="header-medium" id="ancestry">Ancestry</h3>
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    {{data-table
-      options=profile
-      mode=profile.mode
-      reliability=profile.reliability
-      comparison=profile.comparison
-      config=ancestry
-      model=model
-    }}
-  </div>
-</div>
-
-{{profile-footer}}
-
-{{outlet}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -28,7 +28,7 @@ module.exports = function(environment) {
 
     SAMPLE_SELECTION,
 
-    SupportServiceHost: 'http://localhost:4000',
+    SupportServiceHost: 'https://factfinder-api.planninglabs.nyc',
   };
 
   ENV.DEFAULT_SELECTION = {

--- a/config/environment.js
+++ b/config/environment.js
@@ -28,7 +28,7 @@ module.exports = function(environment) {
 
     SAMPLE_SELECTION,
 
-    SupportServiceHost: 'https://factfinder-api.planninglabs.nyc',
+    SupportServiceHost: 'http://localhost:4000',
   };
 
   ENV.DEFAULT_SELECTION = {


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR ensures that census profiles never include grayed out data

Changes Proposed:
- cells classed `medium-gray` will now be classed `insignificant`
- all ACS profiles are wrapped in a div with class `shows-significance`
- a new CSS rule for `.shows-significance .insignficant` is added, changing the color to `$medium-gray`

Closes #315