### PR TITLE
replace default basemap labels with nta labels

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -15,6 +15,7 @@ import highlightedFeature from '../layers/highlighted-feature';
 
 import bkQnMhBoundarySource from '../sources/bk-qn-mh-boundary';
 import bkQnMhBoundaryLayer from '../layers/bk-qn-mh-boundary';
+import subduedNtaLabels from '../layers/subdued-nta-labels';
 
 const selectedFillLayer = selectedFeatures.fill;
 
@@ -41,8 +42,11 @@ export default Ember.Controller.extend({
 
   layerGroups,
   sources,
+
   bkQnMhBoundarySource,
   bkQnMhBoundaryLayer,
+  subduedNtaLabels,
+
   zoom: 12.25,
   center: [-73.9868, 40.724],
   mode: 'direct-select',
@@ -188,6 +192,9 @@ export default Ember.Controller.extend({
       if (this.get('selection.selectedCount')) {
         this.fitBounds(map);
       }
+
+      // remove default neighborhood names
+      map.removeLayer('place-neighbourhood');
     },
   },
 });

--- a/app/layers/subdued-nta-labels.js
+++ b/app/layers/subdued-nta-labels.js
@@ -1,0 +1,36 @@
+export default {
+  id: 'subdued_nta_labels',
+  type: 'symbol',
+  source: 'admin-boundaries',
+  'source-layer': 'neighborhood-tabulation-areas-centroids',
+  paint: {
+    'text-halo-color': 'hsl(0, 0%, 100%)',
+    'text-halo-width': 1,
+    'text-color': 'hsl(0, 0%, 62%)',
+    'text-halo-blur': 0,
+  },
+  layout: {
+    'text-field': '{ntaname}',
+    'text-transform': 'uppercase',
+    'text-letter-spacing': 0.1,
+    'text-max-width': 7,
+    'text-font': [
+      'DIN Offc Pro Regular',
+      'Arial Unicode MS Regular',
+    ],
+    'text-padding': 3,
+    'text-size': {
+      base: 1,
+      stops: [
+        [
+          12,
+          11,
+        ],
+        [
+          16,
+          16,
+        ],
+      ],
+    },
+  },
+};

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -103,9 +103,9 @@ export default Ember.Service.extend({
     const map = this.get('currentMapInstance');
     if (map) {
       if (toLevel === 'ntas') {
-        map.setLayoutProperty('place-neighbourhood', 'visibility', 'none');
+        map.setLayoutProperty('subdued_nta_labels', 'visibility', 'none');
       } else {
-        map.setLayoutProperty('place-neighbourhood', 'visibility', 'visible');
+        map.setLayoutProperty('subdued_nta_labels', 'visibility', 'visible');
       }
     }
 

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -31,6 +31,8 @@
       {{map.layer layer=bkQnMhBoundaryLayer}}
     {{/map.source}}
 
+    {{map.layer layer=subduedNtaLabels}}
+
     {{#if selection.currentAddress}}
       {{#map.source sourceId='currentAddress' options=selection.addressSource as |source|}}
         {{source.layer layer=selection.pointLayer}}


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR hides the default neighborhood names included in the mapbox `composite` source, and adds a new custom layer called `subdued-nta-labels`.  

It also includes some handling to make sure that the subdued labels are not shown when selecting NTAs. (bold labels are shown for the NTAs when in NTA selection mode)

Closes #306
