### PR TITLE
Checkbox query param bug fix

### DIFF
--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -11,6 +11,10 @@ export default Ember.Route.extend({
   selection: service(),
 
   queryParams: {
+    mode: {
+      refreshModel: false,
+      scope: 'controller',
+    },
     comparator: {
       refreshModel: true,
       scope: 'controller',


### PR DESCRIPTION
Bug: when you toggled reliability in Change Over Time mode, the `mode` was resetting to `current`. 

This PR scopes the `mode` query param to profile controller, which avoids resetting `mode` when toggling `charts` or `reliability` query param. 