### PR TITLE
fix scroll-to bug

### DIFF
--- a/app/services/scroller.js
+++ b/app/services/scroller.js
@@ -1,8 +1,23 @@
-import Ember from 'ember';
+import Em from 'ember';
 import Scroller from 'ember-scroll-to/services/scroller';
 
+const { RSVP } = Em;
+
 export default Scroller.extend({
-  scrollable: Ember.computed(function() {
-    return Ember.$('#profile-content');
-  }),
+  scrollVertical (target, opts = {}) {
+    return new RSVP.Promise((resolve, reject) => {
+      // workaround for issue https://github.com/NYCPlanning/labs-nyc-factfinder/issues/304
+      const scrollable = Em.$('#profile-content');
+      scrollable.animate(
+        {
+          scrollTop: (scrollable.scrollTop() - scrollable.offset().top) + this.getVerticalCoord(target, opts.offset),
+        },
+        opts.duration || this.get('duration'),
+        opts.easing || this.get('easing'),
+        opts.complete,
+      )
+        .promise()
+        .then(resolve, reject);
+    });
+  },
 });


### PR DESCRIPTION
This PR fixes the scroll-to bug where scrolling to tables on a profile did not work after transitioning away from and back to a profile.

The `scroll-to` package included a computed property that returned a Jquery selection for the div to be scrolled.  I think that this computed property was not being recalculated after the route transition.  Although the div and id were the same the original one had been destroyed and a new one is created after the transition.

This adds the jQuery selection within `scrollVertical()`, so it's always new every time.  Will also update https://github.com/ragnarpeterson/ember-scroll-to/issues/39 with this information.


Closes #304
