### PR TITLE
522 hide percentage point

### DIFF
--- a/app/models/row.js
+++ b/app/models/row.js
@@ -56,6 +56,7 @@ export default DS.Model.extend({
   notinprofile: DS.attr('string'),
   percent: DS.attr('number'),
   percent_m: DS.attr('number'),
+  previous_percent: DS.attr('number'),
   percent_significant: DS.attr('boolean'),
   producttype: DS.attr('string'),
   release_year: DS.attr('string'),

--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -41,11 +41,11 @@
   {{!-- percent --}}
   <td class="{{unless data.change_percent_significant 'insignificant'}}">
     {{if
-      (and 
-        data.change_percent 
+      (and
+        data.change_percent
         (not data.rowConfig.hidePercentChange)
-        (and 
-          (not data.codingThresholds.sum) 
+        (and
+          (not data.codingThresholds.sum)
           (not data2.codingThresholds.sum)))
         (concat
           (format-number (mult data.change_percent 100) precision=1)
@@ -56,11 +56,11 @@
     {{!-- Percent M --}}
     <td class="{{unless data.change_percent_significant 'insignificant'}}">
       {{if
-        (and 
-          data.change_percent_m 
+        (and
+          data.change_percent_m
           (not data.rowConfig.hidePercentChange)
-          (and 
-            (not data.codingThresholds.sum) 
+          (and
+            (not data.codingThresholds.sum)
             (not data2.codingThresholds.sum)))
           (concat
             (format-number (mult data.change_percent_m 100) precision=1)
@@ -71,8 +71,11 @@
   {{!-- percentage point --}}
   <td class="{{unless data.change_percentage_point_significant 'insignificant'}}">
     {{#unless
-        (or data.isSpecial
-          (and (eq data.sum 0) (eq data2.sum 0)))}}
+        (or
+          data.isSpecial
+          (and (eq data.sum 0) (eq data2.sum 0))
+          (eq data.change_percentage_point null)
+        )}}
       {{format-number
         (mult data.change_percentage_point 100)
         precision=1}}
@@ -83,8 +86,11 @@
     {{!-- percentage point m --}}
     <td class="{{unless data.change_percentage_point_significant 'insignificant'}}">
       {{#unless
-          (or data.isSpecial
-            (and (eq data.sum 0) (eq data2.sum 0)))}}
+          (or
+            data.isSpecial
+            (and (eq data.sum 0) (eq data2.sum 0))
+            (eq data.change_percentage_point null)
+          )}}
         {{format-number
           (mult data.change_percentage_point_m 100)
           precision=1}}

--- a/app/templates/components/data-table-row-current.hbs
+++ b/app/templates/components/data-table-row-current.hbs
@@ -54,7 +54,6 @@
 
     <td
       class="{{unless data.percent_significant 'insignificant'}}">
-      {{log data.variable data.percent data.previous_percent}}
       {{#unless (or
           data.shouldHideDeltaPercent
           (and (eq data.percent null) (eq data.previous_percent null))

--- a/app/templates/components/data-table-row-current.hbs
+++ b/app/templates/components/data-table-row-current.hbs
@@ -54,15 +54,23 @@
 
     <td
       class="{{unless data.percent_significant 'insignificant'}}">
-      {{unless data.shouldHideDeltaPercent
-        (format-number
+      {{log data.variable data.percent data.previous_percent}}
+      {{#unless (or
+          data.shouldHideDeltaPercent
+          (and (eq data.percent null) (eq data.previous_percent null))
+        )}}
+          {{format-number
           data.difference_percent
-          precision=1)}}
+          precision=1}}
+      {{/unless}}
     </td>
     {{#if reliability}}
       <td
         class="{{unless data.percent_significant 'insignificant'}}">
-        {{unless data.shouldHideDeltaPercent
+        {{unless (or
+            data.shouldHideDeltaPercent
+            (and (eq data.percent null) (eq data.previous_percent null))
+          )
           (format-number
             data.difference_percent_m
             precision=1)}}


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds logic to `data-table-row-current` and `data-table-row-change` to hide the right-most percentage point column based on nullness of other percentage columns.

-for current view, hides `difference_percent` and `difference_percent_m` if `data.percent and `data.previous_percent` are both null

-for change over time view, hides data `data.change_percentage_point` and `data.change_percentage_point_m` if `data.change_percentage_point` is null

Closes #522
