### PR TITLE
447 section scroll

### DIFF
--- a/app/components/tab-dropdown.js
+++ b/app/components/tab-dropdown.js
@@ -1,10 +1,90 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
+import { computed } from 'ember-decorators/object';
 
 export default Component.extend({
   isOpen: false,
 
   metrics: service(),
+
+  dropdown: '',
+
+  demographicItems: [
+    { anchor: '#sex-and-age', title: 'Age and Sex' },
+    { anchor: '#mutually-exclusive-race-hispanic-origin', title: 'Mutually Exclusive Race / Hispanic Origin' },
+    { anchor: '#hispanic-subgroup', title: 'Hispanic Subgroup' },
+    { anchor: '#asian-subgroup', title: 'Asian Subgroup' },
+  ],
+
+  socialItems: [
+    { anchor: '#household-type', title: 'Household Type' },
+    { anchor: '#relationship-to-head-of-household', title: 'Relationship To Head Of Household (Householder)' },
+    { anchor: '#grandparents', title: 'Grandparents' },
+    { anchor: '#school-enrollment', title: 'School Enrollment' },
+    { anchor: '#educational-attainment', title: 'Educational Attainment (Highest Grade Completed)' },
+    { anchor: '#veteran-status', title: 'Veteran Status' },
+    { anchor: '#disability-status-of-the-civilian-noninstitutionalized-population', title: 'Disability Status Of The Civilian Noninstitutionalized Population' },
+    { anchor: '#residence-1-year-ago', title: 'Residence 1 Year Ago' },
+    { anchor: '#place-of-birth', title: 'Place Of Birth' },
+    { anchor: '#us-citizenship-status', title: 'U.S. Citizenship Status' },
+    { anchor: '#year-of-entry', title: 'Year Of Entry' },
+    { anchor: '#language-spoken-at-home', title: 'Language Spoken At Home' },
+    { anchor: '#ancestry', title: 'Ancestry' },
+  ],
+
+  economicItems: [
+    { anchor: '#employment-status', title: 'Employment Status' },
+    { anchor: '#commute-to-work', title: 'Commute to Work' },
+    { anchor: '#occupation', title: 'Occupation' },
+    { anchor: '#industry', title: 'Industry' },
+    { anchor: '#class-of-worker', title: 'Class of Worker' },
+    { anchor: '#income-and-benefits', title: 'Income and Benefits' },
+    { anchor: '#earnings', title: 'Earnings' },
+    { anchor: '#health-insurance-coverage', title: 'Health Insurance Coverage' },
+    { anchor: '#income-in-the-past-12-months-below-poverty-level', title: 'Income in the Past 12 Months Below Poverty Level' },
+    { anchor: '#ratio-of-income-to-poverty-level', title: 'Ratio of Income to Poverty Level' },
+  ],
+
+  housingItems: [
+    { anchor: '#housing-occupancy', title: 'Housing Occupancy' },
+    { anchor: '#units-in-structure', title: 'Units in Structure' },
+    { anchor: '#year-structure-built', title: 'Year Structure Built' },
+    { anchor: '#rooms', title: 'Rooms' },
+    { anchor: '#housing-tenure', title: 'Housing Tenure' },
+    { anchor: '#year-householder-moved-into-unit', title: 'Year Householder Moved Into Unit' },
+    { anchor: '#vehicles-available', title: 'Vehicles Available' },
+    { anchor: '#occupants-per-room', title: 'Occupants per Room' },
+    { anchor: '#value', title: 'Value' },
+    { anchor: '#mortgage-status', title: 'Mortgage Status' },
+    { anchor: '#selected-monthly-owner-costs-as-a-percentage-of-household-income', title: 'Selected Monthly Owner Costs as a Percentage of Household Income' },
+    { anchor: '#gross-rent', title: 'Gross Rent' },
+    { anchor: '#gross-rent-as-a-percentage-of-household-income', title: 'Gross Rent as a Percentage of Household Income (GRAPI)' },
+  ],
+
+  @computed('dropdown')
+  dropdownItems() {
+    const demographicItems = this.get('demographicItems');
+    const socialItems = this.get('socialItems');
+    const economicItems = this.get('economicItems');
+    const housingItems = this.get('housingItems');
+
+    const dropdown = this.get('dropdown');
+
+    if (dropdown === 'demographic') {
+      return demographicItems;
+    }
+    if (dropdown === 'social') {
+      return socialItems;
+    }
+    if (dropdown === 'economic') {
+      return economicItems;
+    }
+    if (dropdown === 'housing') {
+      return housingItems;
+    }
+
+    return null;
+  },
 
   actions: {
     closeTabDropdown() {
@@ -19,6 +99,14 @@ export default Component.extend({
       });
 
       this.set('isOpen', !this.get('isOpen'));
+    },
+
+    sendAnalytics(eventAction, eventLabel) {
+      this.get('metrics').trackEvent('GoogleAnalytics', {
+        eventCategory: 'Profile Navigation',
+        eventAction,
+        eventLabel,
+      });
     },
   },
 

--- a/app/services/scroller.js
+++ b/app/services/scroller.js
@@ -1,8 +1,23 @@
-import Ember from 'ember';
+import Em from 'ember';
 import Scroller from 'ember-scroll-to/services/scroller';
 
+const { RSVP } = Em;
+
 export default Scroller.extend({
-  scrollable: Ember.computed(function() {
-    return Ember.$('#profile-content');
-  }),
+  scrollVertical (target, opts = {}) {
+    return new RSVP.Promise((resolve, reject) => {
+      // workaround for issue https://github.com/NYCPlanning/labs-nyc-factfinder/issues/304
+      const scrollable = Em.$('#profile-content');
+      scrollable.animate(
+        {
+          scrollTop: (scrollable.scrollTop() - scrollable.offset().top) + this.getVerticalCoord(target, opts.offset),
+        },
+        opts.duration || this.get('duration'),
+        opts.easing || this.get('easing'),
+        opts.complete,
+      )
+        .promise()
+        .then(resolve, reject);
+    });
+  },
 });

--- a/app/templates/components/tab-dropdown.hbs
+++ b/app/templates/components/tab-dropdown.hbs
@@ -10,5 +10,9 @@
 </span>
 
 <ul class="tab-dropdown menu vertical {{if (eq isOpen false) 'hide'}}">
-  {{yield (hash scroll-to=(component 'scroll-to' afterScroll=(action 'closeTabDropdown')))}}
+  {{#each dropdownItems as |item|}}
+    <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' item.title}}>
+      {{#scroll-to href=item.anchor afterScroll=(action 'closeTabDropdown')}}{{item.title}}{{/scroll-to}}
+    </li>
+  {{/each}}
 </ul>

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -64,23 +64,7 @@
         {{else}}
           <li>
             {{#if (eq tab 'profile.demographic')}}
-              {{#tab-dropdown
-                tabName='Demographic'
-                tabNameSmall='(ACS)'
-                as |item| }}
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Age and Sex'}}>
-                  {{#item.scroll-to href='#sex-and-age'}}Age and Sex{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Mutually Exclusive Race / Hispanic Origin'}}>
-                  {{#item.scroll-to href='#mutually-exclusive-race-hispanic-origin'}}Mutually Exclusive Race / Hispanic Origin{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Hispanic Subgroup'}}>
-                  {{#item.scroll-to href='#hispanic-subgroup'}}Hispanic Subgroup{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Asian Subgroup'}}>
-                  {{#item.scroll-to href='#asian-subgroup'}}Asian Subgroup{{/item.scroll-to}}
-                </li>
-              {{/tab-dropdown}}
+              {{tab-dropdown tabName='Demographic' tabNameSmall='(ACS)' dropdown='demographic'}}
             {{else}}
               {{#link-to
                 'profile.demographic'
@@ -94,50 +78,7 @@
           </li>
           <li>
             {{#if (eq tab 'profile.social')}}
-              {{#tab-dropdown
-                tabName='Social'
-                tabNameSmall='(ACS)'
-                as |item| }}
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Household Type'}}>
-                  {{#item.scroll-to href='#household-type'}}Household Type{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Relationship To Head Of Household (Householder'}}>
-                  {{#item.scroll-to href='#relationship-to-head-of-household'}}Relationship To Head Of Household (Householder){{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Grandparents'}}>
-                  {{#item.scroll-to href='#grandparents'}}Grandparents{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'School Enrollment'}}>
-                  {{#item.scroll-to href='#school-enrollment'}}School Enrollment{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Educational Attainment (Highest Grade Completed)'}}>
-                  {{#item.scroll-to href='#educational-attainment'}}Educational Attainment (Highest Grade Completed){{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Veteran Status'}}>
-                  {{#item.scroll-to href='#veteran-status'}}Veteran Status{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Disability Status Of The Civilian Noninstitutionalized Population'}}>
-                  {{#item.scroll-to href='#disability-status-of-the-civilian-noninstitutionalized-population'}}Disability Status Of The Civilian Noninstitutionalized Population{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Residence 1 Year Ago'}}>
-                  {{#item.scroll-to href='#residence-1-year-ago'}}Residence 1 Year Ago{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Place Of Birth'}}>
-                  {{#item.scroll-to href='#place-of-birth'}}Place Of Birth{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'U.S. Citizenship Status'}}>
-                  {{#item.scroll-to href='#us-citizenship-status'}}U.S. Citizenship Status{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Year Of Entry'}}>
-                  {{#item.scroll-to href='#year-of-entry'}}Year Of Entry{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Language Spoken At Home'}}>
-                  {{#item.scroll-to href='#language-spoken-at-home'}}Language Spoken At Home{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Ancestry'}}>
-                  {{#item.scroll-to href='#ancestry'}}Ancestry{{/item.scroll-to}}
-                </li>
-              {{/tab-dropdown}}
+              {{tab-dropdown tabName='Social' tabNameSmall='(ACS)' dropdown='social'}}
             {{else}}
               {{#link-to
                 'profile.social'
@@ -151,41 +92,7 @@
           </li>
           <li>
             {{#if (eq tab 'profile.economic')}}
-              {{#tab-dropdown
-                tabName='Economic'
-                tabNameSmall='(ACS)'
-                as |item| }}
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Employment Status'}}>
-                  {{#item.scroll-to href='#employment-status'}}Employment Status{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Commute to Work'}}>
-                  {{#item.scroll-to href='#commute-to-work'}}Commute to Work{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Occupation'}}>
-                  {{#item.scroll-to href='#occupation'}}Occupation{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Industry'}}>
-                  {{#item.scroll-to href='#industry'}}Industry{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Class of Worker'}}>
-                  {{#item.scroll-to href='#class-of-worker'}}Class of Worker{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Income and Benefits'}}>
-                  {{#item.scroll-to href='#income-and-benefits'}}Income and Benefits{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Earnings'}}>
-                  {{#item.scroll-to href='#earnings'}}Earnings{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Health Insurance Coverage'}}>
-                  {{#item.scroll-to href='#health-insurance-coverage'}}Health Insurance Coverage{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Income in the Past 12 Months Below Poverty Level'}}>
-                  {{#item.scroll-to href='#income-in-the-past-12-months-below-poverty-level'}}Income in the Past 12 Months Below Poverty Level{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Ratio of Income to Poverty Level'}}>
-                  {{#item.scroll-to href='#ratio-of-income-to-poverty-level'}}Ratio of Income to Poverty Level{{/item.scroll-to}}
-                </li>
-              {{/tab-dropdown}}
+              {{tab-dropdown tabName='Economic' tabNameSmall='(ACS)' dropdown='economic'}}
             {{else}}
               {{#link-to
                 'profile.economic'
@@ -199,50 +106,7 @@
           </li>
           <li>
             {{#if (eq tab 'profile.housing')}}
-              {{#tab-dropdown
-                tabName='Housing'
-                tabNameSmall='(ACS)'
-                as |item| }}
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Housing Occupancy'}}>
-                  {{#item.scroll-to href='#housing-occupancy'}}Housing Occupancy{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Units in Structure'}}>
-                  {{#item.scroll-to href='#units-in-structure'}}Units in Structure{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Year Structure Built'}}>
-                  {{#item.scroll-to href='#year-structure-built'}}Year Structure Built{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Rooms'}}>
-                  {{#item.scroll-to href='#rooms'}}Rooms{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Housing Tenure'}}>
-                  {{#item.scroll-to href='#housing-tenure'}}Housing Tenure{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Year Householder Moved Into Unit'}}>
-                  {{#item.scroll-to href='#year-householder-moved-into-unit'}}Year Householder Moved Into Unit{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Vehicles Available'}}>
-                  {{#item.scroll-to href='#vehicles-available'}}Vehicles Available{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Occupants per Room'}}>
-                  {{#item.scroll-to href='#occupants-per-room'}}Occupants per Room{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Value'}}>
-                  {{#item.scroll-to href='#value'}}Value{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Mortgage Status'}}>
-                  {{#item.scroll-to href='#mortgage-status'}}Mortgage Status{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Selected Monthly Owner Costs as a Percentage of Household Income'}}>
-                  {{#item.scroll-to href='#selected-monthly-owner-costs-as-a-percentage-of-household-income'}}Selected Monthly Owner Costs as a Percentage of Household Income{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Gross Rent'}}>
-                  {{#item.scroll-to href='#gross-rent'}}Gross Rent{{/item.scroll-to}}
-                </li>
-                <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Gross Rent as a Percentage of Household Income (GRAPI)'}}>
-                  {{#item.scroll-to href='#gross-rent-as-a-percentage-of-household-income'}}Gross Rent as a Percentage of Household Income (GRAPI){{/item.scroll-to}}
-                </li>
-              {{/tab-dropdown}}
+              {{tab-dropdown tabName='Housing' tabNameSmall='(ACS)' dropdown='housing'}}
             {{else}}
               {{#link-to
                 'profile.housing'


### PR DESCRIPTION
This PR… 
- Refactors the `tab-dropdown` component to minimize repeated code (there was a lot of repeated markup for every dropdown list item, which are now in an `{{each}}` template) 
- Reimplements @chriswhong's fix for the `{{scroll-to}}` addon not working on 2nd visits to `profile/` route (Closes #447 )

I'm not sure about why Chris's fix was removed. If you look at the [history of `scroller.js`](https://github.com/NYCPlanning/labs-nyc-factfinder/commits/develop/app/services/scroller.js), you can see that Chris's "fix scroll-to bug" was manually undone by @allthesignals. I can't tell from the subsequent commits if that was intentional. See also [ember-scroll-to issue](https://github.com/ragnarpeterson/ember-scroll-to/issues/39)